### PR TITLE
Add animated FAQ accordion and restore FAQ stack visibility

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -344,3 +344,97 @@ h1, h2, h3, h4, h5, h6 {
     filter: none;
   }
 }
+
+/* FAQ Accordion */
+.faq-accordion {
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+}
+
+.faq-accordion-card {
+  position: relative;
+  background: rgba(255, 255, 255, 0.98);
+  border-radius: 22px;
+  border: 1px solid rgba(203, 212, 194, 0.6);
+  box-shadow: 0 24px 48px -32px rgba(11, 86, 118, 0.22);
+  padding: 1.5rem 1.75rem;
+  transition: border-color 0.3s ease, box-shadow 0.3s ease, transform 0.3s ease;
+}
+
+.faq-accordion-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 30px 56px -28px rgba(11, 86, 118, 0.28);
+}
+
+.faq-accordion-card[data-open='true'] {
+  border-color: rgba(13, 161, 225, 0.55);
+  box-shadow: 0 36px 72px -28px rgba(13, 161, 225, 0.3);
+  transform: translateY(-4px);
+}
+
+.faq-accordion-trigger {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  width: 100%;
+  background: none;
+  border: 0;
+  padding: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #2a2a2b;
+  text-align: left;
+  cursor: pointer;
+}
+
+.faq-accordion-trigger:focus-visible {
+  outline: 3px solid rgba(13, 161, 225, 0.35);
+  outline-offset: 4px;
+}
+
+.faq-accordion-question {
+  flex: 1;
+}
+
+.faq-accordion-icon {
+  flex-shrink: 0;
+  width: 2.5rem;
+  height: 2.5rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 9999px;
+  background: linear-gradient(135deg, rgba(13, 161, 225, 0.12), rgba(92, 201, 112, 0.08));
+  color: #0da1e1;
+  transition: transform 0.3s ease, background 0.3s ease, color 0.3s ease;
+}
+
+.faq-accordion-card[data-open='true'] .faq-accordion-icon {
+  transform: rotate(180deg);
+  background: linear-gradient(135deg, #0da1e1, #32b1e8);
+  color: #ffffff;
+}
+
+.faq-accordion-answer {
+  overflow: hidden;
+  max-height: 0;
+  opacity: 0;
+  padding-top: 0;
+  transition: max-height 0.35s ease, opacity 0.3s ease, padding-top 0.3s ease;
+}
+
+.faq-accordion-card[data-open='true'] .faq-accordion-answer {
+  opacity: 1;
+  padding-top: 1rem;
+}
+
+.faq-accordion-answer-inner {
+  color: rgba(57, 57, 58, 0.92);
+  line-height: 1.65;
+}
+
+.faq-accordion-answer-inner p {
+  margin: 0;
+}

--- a/src/components/FAQAccordion.tsx
+++ b/src/components/FAQAccordion.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import { ChevronDown } from 'lucide-react';
+
+type FAQ = {
+  question: string;
+  answer: string;
+};
+
+type FAQAccordionProps = {
+  faqs: FAQ[];
+  className?: string;
+  defaultOpenIndex?: number | null;
+};
+
+const FAQAccordion: React.FC<FAQAccordionProps> = ({ faqs, className = '', defaultOpenIndex = 0 }) => {
+  const contentRefs = React.useRef<(HTMLDivElement | null)[]>([]);
+  const [heights, setHeights] = React.useState<number[]>([]);
+  const [activeIndex, setActiveIndex] = React.useState<number | null>(
+    faqs.length > 0 && defaultOpenIndex !== null && defaultOpenIndex >= 0 && defaultOpenIndex < faqs.length
+      ? defaultOpenIndex
+      : null,
+  );
+
+  React.useEffect(() => {
+    const updateHeights = () => {
+      contentRefs.current = contentRefs.current.slice(0, faqs.length);
+      setHeights(faqs.map((_, index) => contentRefs.current[index]?.scrollHeight ?? 0));
+    };
+
+    updateHeights();
+
+    if (typeof window !== 'undefined') {
+      window.addEventListener('resize', updateHeights);
+      return () => window.removeEventListener('resize', updateHeights);
+    }
+
+    return undefined;
+  }, [faqs]);
+
+  React.useEffect(() => {
+    if (faqs.length === 0) {
+      setActiveIndex(null);
+      return;
+    }
+
+    if (activeIndex !== null && activeIndex < faqs.length) {
+      return;
+    }
+
+    if (defaultOpenIndex !== null && defaultOpenIndex >= 0 && defaultOpenIndex < faqs.length) {
+      setActiveIndex(defaultOpenIndex);
+    } else {
+      setActiveIndex(null);
+    }
+  }, [faqs, activeIndex, defaultOpenIndex]);
+
+  const toggle = (index: number) => {
+    setActiveIndex((prev) => (prev === index ? null : index));
+  };
+
+  if (!faqs || faqs.length === 0) {
+    return (
+      <div className={`faq-accordion ${className}`.trim()}>
+        <div className="faq-accordion-card" data-open="false">
+          <button type="button" className="faq-accordion-trigger" disabled>
+            <span className="faq-accordion-question">FAQs are on their way.</span>
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`faq-accordion ${className}`.trim()}>
+      {faqs.map((faq, index) => {
+        const isOpen = activeIndex === index;
+        const measuredHeight = contentRefs.current[index]?.scrollHeight ?? 0;
+        const maxHeight = isOpen ? heights[index] ?? measuredHeight : 0;
+
+        return (
+          <article key={faq.question} className="faq-accordion-card" data-open={isOpen}>
+            <button
+              type="button"
+              className="faq-accordion-trigger"
+              onClick={() => toggle(index)}
+              aria-expanded={isOpen}
+              aria-controls={`faq-panel-${index}`}
+              id={`faq-trigger-${index}`}
+            >
+              <span className="faq-accordion-question">{faq.question}</span>
+              <span className="faq-accordion-icon" aria-hidden="true">
+                <ChevronDown size={22} strokeWidth={2.4} />
+              </span>
+            </button>
+            <div
+              id={`faq-panel-${index}`}
+              role="region"
+              aria-labelledby={`faq-trigger-${index}`}
+              className="faq-accordion-answer"
+              style={{ maxHeight: `${maxHeight}px` }}
+            >
+              <div
+                className="faq-accordion-answer-inner"
+                ref={(node) => {
+                  contentRefs.current[index] = node;
+                }}
+              >
+                <p>{faq.answer}</p>
+              </div>
+            </div>
+          </article>
+        );
+      })}
+    </div>
+  );
+};
+
+export default FAQAccordion;

--- a/src/components/FAQStack.tsx
+++ b/src/components/FAQStack.tsx
@@ -105,10 +105,10 @@ const FAQStack: React.FC<FAQStackProps> = ({
             data-state={position}
             style={{
               '--stack-index': index,
-              display: index === activeIndex ? 'block' : 'none', // Only show active
             } as React.CSSProperties & { '--stack-index': number }}
             tabIndex={0}
             aria-current={index === activeIndex}
+            aria-hidden={index !== activeIndex}
           >
             <div className="faq-card__glow" aria-hidden="true" />
             <h3 className={questionClassName}>{faq.question}</h3>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -19,6 +19,7 @@ import QuoteForm from '../components/QuoteForm';
 import SEO from '../components/SEO';
 import TestimonialCarousel from '../components/TestimonialCarousel';
 import { useScrollToSection } from '../hooks/useScrollToSection';
+import FAQAccordion from '../components/FAQAccordion';
 
 const Home: React.FC = () => {
   const services = [
@@ -174,6 +175,34 @@ const testimonials = [
       step: '04',
       title: 'Quality Assurance',
       description: 'Supervisors complete audits, review KPIs with you and adjust scope as needs evolve.',
+    },
+  ];
+
+  const faqs = [
+    {
+      question: 'How quickly can you start cleaning our site?',
+      answer:
+        'After your quote is accepted we can schedule onboarding within 5–7 business days. This includes a site walkthrough, inductions for your dedicated crew and confirmation of access requirements so the first clean runs smoothly.',
+    },
+    {
+      question: 'Do you bring all cleaning products and equipment?',
+      answer:
+        'Yes. Our teams arrive with commercial-grade equipment, colour-coded microfibre systems and TGA-approved disinfectants. We can also use client-supplied consumables if you have specific brand standards or sustainability policies to follow.',
+    },
+    {
+      question: 'Can cleans happen outside of trading hours?',
+      answer:
+        'Absolutely. Evening, overnight and early-morning schedules are part of our standard service. We coordinate with your security and facilities teams to make sure access, alarms and lock-up procedures are followed every visit.',
+    },
+    {
+      question: 'How do you maintain consistent quality?',
+      answer:
+        'Every account has a supervisor who performs regular audits, uses photo checklists and meets with you quarterly to review KPIs. Any issues trigger corrective actions within the same shift or the next scheduled visit.',
+    },
+    {
+      question: 'Are you covered for insurance and compliance?',
+      answer:
+        'We hold full public liability insurance, workers compensation, up-to-date police checks and industry-specific certifications. All documentation is provided during onboarding and kept ready for your compliance records.',
     },
   ];
 
@@ -458,6 +487,18 @@ const testimonials = [
               Learn More About Our Process
             </Link>
           </div>
+        </div>
+      </section>
+
+      <section className="py-20 px-4 sm:px-6 lg:px-8 bg-white border-t border-ash-gray/20">
+        <div className="container-max">
+          <div className="text-center mb-14 animate-fade-in">
+            <h2 className="text-3xl md:text-4xl font-bold mb-6 text-charcoal">Frequently Asked Questions</h2>
+            <p className="text-lg md:text-xl text-jet max-w-3xl mx-auto">
+              Straightforward answers about onboarding, scheduling and the compliance standards we bring to Brisbane facilities.
+            </p>
+          </div>
+          <FAQAccordion faqs={faqs} className="max-w-4xl mx-auto" />
         </div>
       </section>
 


### PR DESCRIPTION
## Summary
- ensure the existing FAQ stack cards remain visible while keeping accessibility hints
- introduce a reusable animated FAQ accordion component with supporting styles
- showcase the accordion on the home page with Brisbane-focused onboarding FAQs

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dfb47b65688327b78b269c98190872