### PR TITLE
Refine hero messaging with concise two-line copy

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,11 +1,11 @@
-﻿@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Poppins:wght@400;500;600;700&display=swap');
+﻿@import url('https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&family=Space+Grotesk:wght@500;600;700&display=swap');
 
 * {
   box-sizing: border-box;
 }
 
 body {
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
+  font-family: 'Plus Jakarta Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
   line-height: 1.65;
   color: #172339;
   background: radial-gradient(circle at top left, rgba(13, 161, 225, 0.08) 0%, rgba(92, 201, 112, 0.04) 36%, #f7f9fc 100%);
@@ -18,7 +18,7 @@ h3,
 h4,
 h5,
 h6 {
-  font-family: 'Poppins', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
+  font-family: 'Space Grotesk', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
   line-height: 1.15;
   color: #0b1729;
 }
@@ -122,24 +122,34 @@ h6 {
 }
 
 .btn-primary {
-  @apply inline-flex items-center justify-center gap-2 rounded-full px-8 py-3 text-base font-semibold transition-all duration-300 focus:outline-none focus-visible:ring-4 focus-visible:ring-[rgba(92,139,172,0.45)];
-  color: #f4fbf9;
-  background: rgba(11, 36, 30, 0.65);
-  border: 1px solid rgba(98, 149, 185, 0.55);
-  backdrop-filter: blur(18px);
-  box-shadow: 0 28px 60px -28px rgba(9, 32, 36, 0.65);
+  @apply inline-flex items-center justify-center gap-2 rounded-full px-8 py-3 text-base font-semibold transition-all duration-300 focus:outline-none focus-visible:ring-4 focus-visible:ring-[rgba(80,150,255,0.4)];
+  padding-inline: clamp(1.85rem, 3.6vw, 3rem);
+  padding-block: clamp(0.95rem, 1.3vw, 1.2rem);
+  font-size: clamp(1rem, 0.3vw + 1rem, 1.12rem);
+  letter-spacing: -0.01em;
+  color: #03121f;
+  background: linear-gradient(135deg, rgba(167, 244, 222, 0.98) 0%, rgba(119, 210, 255, 0.98) 48%, rgba(88, 160, 255, 0.98) 100%);
+  border: none;
+  box-shadow: 0 32px 72px -30px rgba(68, 150, 255, 0.64);
 }
 
 .btn-primary:hover {
-  background: rgba(11, 36, 30, 0.78);
-  border-color: rgba(112, 168, 205, 0.65);
-  transform: translateY(-2px);
-  box-shadow: 0 32px 68px -30px rgba(9, 32, 36, 0.7);
+  background: linear-gradient(135deg, rgba(182, 248, 229, 1) 0%, rgba(136, 219, 255, 1) 48%, rgba(103, 173, 255, 1) 100%);
+  transform: translateY(-3px);
+  box-shadow: 0 38px 82px -32px rgba(68, 150, 255, 0.72);
 }
 
 .btn-primary:active {
-  background: rgba(9, 30, 25, 0.88);
-  transform: translateY(0);
+  transform: translateY(-1px);
+  box-shadow: 0 24px 56px -28px rgba(68, 150, 255, 0.58);
+}
+
+.btn-primary--elevated {
+  box-shadow: 0 34px 90px -32px rgba(72, 162, 255, 0.72), 0 18px 46px -28px rgba(19, 76, 134, 0.48);
+}
+
+.btn-primary--elevated:hover {
+  box-shadow: 0 38px 98px -30px rgba(85, 176, 255, 0.78), 0 24px 52px -28px rgba(27, 92, 158, 0.46);
 }
 
 .btn-secondary {
@@ -161,13 +171,24 @@ h6 {
 }
 
 .btn-ghost {
-  @apply inline-flex items-center justify-center gap-2 rounded-full border border-white/50 px-6 py-3 text-base font-semibold text-white transition-all duration-300 backdrop-blur;
-  background: rgba(255, 255, 255, 0.06);
+  @apply inline-flex items-center justify-center gap-2 rounded-full px-6 py-3 text-base font-semibold transition-all duration-300 backdrop-blur;
+  letter-spacing: -0.005em;
+  color: rgba(243, 247, 252, 0.92);
+  border: 1px solid rgba(255, 255, 255, 0.5);
+  background: rgba(12, 30, 45, 0.45);
 }
 
 .btn-ghost:hover {
-  background: rgba(255, 255, 255, 0.16);
-  transform: translateY(-1px);
+  background: rgba(16, 40, 60, 0.6);
+  transform: translateY(-2px);
+}
+
+.text-gradient {
+  background: linear-gradient(120deg, rgba(182, 248, 229, 1) 0%, rgba(141, 217, 255, 1) 52%, rgba(103, 173, 255, 1) 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  font-weight: 600;
 }
 
 .section-padding {
@@ -179,21 +200,21 @@ h6 {
 }
 
 :root {
-  --hero-top-spacing: clamp(5.75rem, 4.5vw + 3.1rem, 7.5rem);
-  --hero-bottom-spacing: clamp(3.9rem, 3vw + 2.1rem, 5.75rem);
+  --hero-top-spacing: clamp(8.9rem, 7vw + 4.45rem, 11.6rem);
+  --hero-bottom-spacing: clamp(7.2rem, 6vw + 3.2rem, 9.8rem);
 }
 
 @media (max-width: 1024px) {
   :root {
-    --hero-top-spacing: clamp(5.4rem, 4.5vw + 2.6rem, 6.75rem);
-    --hero-bottom-spacing: clamp(3.6rem, 3.5vw + 1.9rem, 5rem);
+    --hero-top-spacing: clamp(7.9rem, 7vw + 3.7rem, 10.2rem);
+    --hero-bottom-spacing: clamp(6.5rem, 6vw + 2.9rem, 8.8rem);
   }
 }
 
 @media (max-width: 640px) {
   :root {
-    --hero-top-spacing: clamp(5rem, 5.5vw + 2.2rem, 6.1rem);
-    --hero-bottom-spacing: clamp(3.2rem, 3.6vw + 1.6rem, 4.35rem);
+    --hero-top-spacing: clamp(6.6rem, 7vw + 3rem, 8.6rem);
+    --hero-bottom-spacing: clamp(5.9rem, 6vw + 2.4rem, 7.6rem);
   }
 }
 
@@ -215,305 +236,205 @@ h6 {
   gap: clamp(2rem, 4vw, 3rem);
 }
 
-.hero-shell {
+.hero-minimal {
   position: relative;
   isolation: isolate;
   overflow: hidden;
-  border-radius: clamp(30px, 5vw, 48px);
-  background: linear-gradient(160deg, rgba(242, 232, 207, 0.78) 0%, rgba(255, 255, 255, 0.96) 56%, rgba(236, 244, 239, 0.92) 100%);
-  border: 1px solid rgba(91, 138, 114, 0.18);
-  color: var(--hero-foreground, #132019);
-  box-shadow: 0 48px 120px -72px rgba(19, 47, 36, 0.4);
+  width: 100%;
+  margin-inline: 0;
+  min-height: clamp(440px, 58vh, 600px);
+  display: flex;
+  align-items: center;
+  background: #040d16;
+  color: #f7fbff;
 }
 
-.hero-shell,
-.hero-shell[data-theme='spruce'],
-.hero-shell[data-theme='evergreen'],
-.hero-shell[data-theme='charcoal'] {
-  --hero-accent: #5b8a72;
-  --hero-accent-soft: rgba(91, 138, 114, 0.22);
-  --hero-foreground: #132019;
-  --hero-muted: rgba(19, 32, 25, 0.72);
-  --hero-contrast: rgba(255, 255, 255, 0.82);
-}
-
-.hero-shell::before,
-.hero-shell::after {
-  content: '';
-  position: absolute;
-  border-radius: 999px;
-  filter: blur(0px);
-  opacity: 0.75;
-  z-index: 0;
-}
-
-.hero-shell::before {
-  width: clamp(240px, 30vw, 360px);
-  height: clamp(240px, 30vw, 360px);
-  background: radial-gradient(circle at 30% 30%, rgba(91, 138, 114, 0.26), transparent 68%);
-  top: clamp(-5rem, -12vw, -3.5rem);
-  right: clamp(-6rem, -10vw, -2.5rem);
-}
-
-.hero-shell::after {
-  width: clamp(220px, 32vw, 380px);
-  height: clamp(220px, 32vw, 380px);
-  background: radial-gradient(circle at 70% 70%, rgba(242, 232, 207, 0.65), transparent 70%);
-  bottom: clamp(-6rem, -11vw, -3.75rem);
-  left: clamp(-7rem, -12vw, -3rem);
-}
-
-.hero-shell__backdrop {
+.hero-minimal__media,
+.hero-minimal__scrim {
   position: absolute;
   inset: 0;
-  z-index: 0;
-  overflow: hidden;
+  pointer-events: none;
 }
 
+.hero-minimal__media {
+  z-index: 0;
+}
 
-.hero-shell__backdrop img {
+.hero-minimal__media img {
   width: 100%;
   height: 100%;
   object-fit: cover;
-  filter: saturate(1.03) contrast(1.02);
+  object-position: center;
+  filter: saturate(1.08) contrast(1.06);
+  transform: scale(1.12);
 }
 
-.hero-shell[data-variant='photo'] {
-  border-radius: 0;
-  border: none;
-  background: rgba(8, 22, 17, 0.18);
-  color: rgba(244, 247, 244, 0.96);
-  box-shadow: none;
-}
-
-.hero-shell[data-variant='photo']::before,
-.hero-shell[data-variant='photo']::after {
-  display: none;
-}
-
-.hero-shell__container {
-  position: relative;
+.hero-minimal__scrim {
   z-index: 1;
+  background: linear-gradient(120deg, rgba(3, 12, 20, 0.78) 0%, rgba(3, 12, 20, 0.54) 48%, rgba(3, 12, 20, 0.28) 100%);
 }
 
+.hero-minimal__scrim[data-overlay='spruce'] {
+  background: linear-gradient(120deg, rgba(6, 26, 18, 0.8) 0%, rgba(6, 26, 18, 0.52) 48%, rgba(6, 26, 18, 0.26) 100%);
+}
 
-.hero-shell__inner {
-  min-height: clamp(360px, 48vh, 520px);
-  display: flex;
-  align-items: center;
-  justify-content: center;
+.hero-minimal__scrim[data-overlay='charcoal'] {
+  background: linear-gradient(120deg, rgba(8, 10, 12, 0.86) 0%, rgba(8, 10, 12, 0.6) 45%, rgba(8, 10, 12, 0.32) 100%);
+}
+
+.hero-minimal__container {
+  position: relative;
+  z-index: 2;
   width: 100%;
-  padding-block: clamp(2.8rem, 4vw, 4.8rem);
+  padding-inline: clamp(1.75rem, 4vw, 4rem);
 }
 
-.hero-shell__copy {
+.hero-minimal__content {
   display: flex;
   flex-direction: column;
-  gap: clamp(1rem, 2vw, 1.6rem);
-  max-width: min(48rem, 100%);
-}
-
-.hero-shell[data-variant='photo'] .hero-shell__copy {
-  padding: clamp(1.5rem, 3vw, 2.5rem) clamp(1.2rem, 2.4vw, 2.1rem);
-  background: none;
-  border: none;
-  box-shadow: none;
-}
-
-.hero-shell__copy[data-align='center'] {
+  gap: clamp(1.1rem, 2vw, 1.8rem);
+  max-width: min(42rem, 100%);
+  margin-inline: auto;
   text-align: center;
   align-items: center;
-  margin-inline: auto;
 }
 
-.hero-shell__copy[data-align='left'] {
+.hero-minimal__content[data-align='left'] {
   text-align: left;
   align-items: flex-start;
   margin-inline: 0;
   max-width: min(44rem, 100%);
 }
 
-.hero-eyebrow {
+.hero-minimal__eyebrow {
   display: inline-flex;
   align-items: center;
   gap: 0.55rem;
-  padding: 0.55rem 1.4rem;
+  padding: 0.55rem 1.6rem;
   border-radius: 999px;
-  border: 1px solid rgba(91, 138, 114, 0.32);
-  background: rgba(255, 255, 255, 0.8);
-  color: #5b8a72;
+  border: 1px solid rgba(162, 206, 255, 0.45);
+  background: rgba(9, 30, 48, 0.6);
+  color: rgba(236, 244, 255, 0.92);
   font-size: 0.75rem;
   font-weight: 700;
   letter-spacing: 0.28em;
   text-transform: uppercase;
+  backdrop-filter: blur(14px);
+  box-shadow: inset 0 0 0 1px rgba(80, 160, 255, 0.32), 0 18px 36px -26px rgba(17, 62, 110, 0.58);
+  margin-top: clamp(0.4rem, 1.1vw, 1.1rem);
 }
 
-.hero-shell[data-variant='photo'] .hero-eyebrow {
-  background: rgba(244, 247, 244, 0.12);
-  border-color: rgba(242, 232, 207, 0.42);
-  color: #f2e8cf;
-}
-
-
-.hero-shell__title {
-  font-size: clamp(3.1rem, 4vw + 1.8rem, 4.6rem);
-  font-weight: 700;
-  letter-spacing: -0.04em;
-  line-height: 1.04;
-  color: var(--hero-foreground, #132019);
-  max-width: clamp(16ch, 46vw, 20ch);
-  margin-inline: auto;
-}
-
-.hero-shell__copy[data-align='left'] .hero-shell__title {
-  margin-inline: 0;
-}
-
-.hero-shell[data-variant='photo'] .hero-shell__title {
-  color: rgba(255, 255, 255, 0.96);
-  text-shadow: 0 24px 60px rgba(8, 20, 15, 0.55), 0 10px 30px rgba(8, 20, 15, 0.45);
-}
-
-
-.hero-shell__description {
-  font-size: clamp(1.05rem, 1vw + 1rem, 1.35rem);
-  line-height: 1.6;
-  color: var(--hero-muted, rgba(19, 32, 25, 0.72));
-  max-width: 38rem;
-}
-
-.hero-shell__copy[data-align='center'] .hero-shell__description {
-  margin-inline: auto;
-}
-
-.hero-shell[data-variant='photo'] .hero-shell__description {
-  color: rgba(244, 247, 244, 0.9);
-  text-shadow: 0 16px 40px rgba(8, 20, 15, 0.45);
-}
-
-
-.hero-shell__actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.9rem;
-  justify-content: center;
-  margin-top: clamp(0.2rem, 1vw, 0.85rem);
-}
-
-.hero-shell__copy[data-align='left'] .hero-shell__actions {
-  justify-content: flex-start;
-}
-
-.hero-shell__badges {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
-  justify-content: center;
-}
-
-.hero-shell__copy[data-align='left'] .hero-shell__badges {
-  justify-content: flex-start;
-}
-
-.hero-shell__badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.55rem;
-  padding: 0.6rem 1.1rem;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.72);
-  border: 1px solid rgba(91, 138, 114, 0.22);
-  color: var(--hero-foreground, #132019);
-  font-size: 0.85rem;
+.hero-minimal__title {
+  font-size: clamp(3.2rem, 4.5vw + 1.5rem, 4.9rem);
   font-weight: 600;
-  letter-spacing: -0.01em;
+  line-height: 1;
+  letter-spacing: -0.02em;
+  color: rgba(244, 248, 255, 0.98);
+  text-wrap: balance;
+  text-shadow: 0 34px 48px rgba(3, 11, 19, 0.65);
 }
 
-.hero-shell__badge svg {
-  width: 1rem;
-  height: 1rem;
+.hero-minimal__title-line {
+  display: block;
 }
 
-.hero-shell[data-variant='photo'] .hero-shell__badge {
-  background: rgba(244, 247, 244, 0.08);
-  border-color: rgba(244, 247, 244, 0.2);
-  color: rgba(244, 247, 244, 0.85);
+.hero-minimal--home .hero-minimal__title-line {
+  white-space: nowrap;
 }
 
-.hero-shell__features {
+.hero-minimal__title-line + .hero-minimal__title-line {
+  margin-top: clamp(0.25rem, 0.7vw, 0.55rem);
+}
+
+@media (max-width: 640px) {
+  .hero-minimal--home .hero-minimal__title {
+    font-size: clamp(2.2rem, 7vw + 1.1rem, 3.4rem);
+  }
+}
+
+.hero-minimal__description {
+  font-size: clamp(1.1rem, 1vw + 1.05rem, 1.35rem);
+  line-height: 1.6;
+  letter-spacing: 0.005em;
+  color: rgba(230, 240, 250, 0.88);
+  max-width: 38rem;
+  text-wrap: balance;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.hero-minimal__actions {
   display: flex;
   flex-wrap: wrap;
-  gap: clamp(0.85rem, 1.6vw, 1.35rem);
+  gap: clamp(0.9rem, 1.8vw, 1.2rem);
   justify-content: center;
-  max-width: min(64rem, 100%);
-  margin-inline: auto;
+  margin-top: clamp(0.3rem, 0.9vw, 1.1rem);
 }
 
-.hero-shell__copy[data-align='left'] .hero-shell__features {
+.hero-minimal__content[data-align='left'] .hero-minimal__actions {
   justify-content: flex-start;
 }
 
-.hero-shell__feature {
-  display: flex;
-  align-items: center;
-  gap: 0.8rem;
-  padding: 0.85rem 1.2rem;
-  border-radius: 18px;
-  background: rgba(255, 255, 255, 0.68);
-  border: 1px solid rgba(91, 138, 114, 0.18);
-  backdrop-filter: blur(18px);
-  flex: 1 1 clamp(12.5rem, 22vw, 18rem);
-  justify-content: flex-start;
-}
-
-.hero-shell__feature-copy {
+.hero-minimal__cta-group {
   display: flex;
   flex-direction: column;
-  gap: 0.2rem;
+  align-items: center;
+  gap: clamp(0.85rem, 1.8vw, 1.4rem);
+  width: 100%;
 }
 
-.hero-shell[data-variant='photo'] .hero-shell__feature {
-  background: rgba(16, 32, 26, 0.56);
-  border-color: rgba(244, 247, 244, 0.16);
+.hero-minimal__cta-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: clamp(0.85rem, 1.6vw, 1.15rem);
 }
 
-.hero-shell__feature-icon {
-  display: grid;
-  place-items: center;
-  width: 2.25rem;
-  height: 2.25rem;
-  border-radius: 12px;
-  background: rgba(91, 138, 114, 0.12);
-  color: #5b8a72;
+.hero-minimal__cta-note {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: rgba(219, 234, 248, 0.9);
+  font-size: 0.96rem;
+  letter-spacing: 0.01em;
 }
 
-.hero-shell[data-variant='photo'] .hero-shell__feature-icon {
-  background: rgba(244, 247, 244, 0.12);
-  color: rgba(244, 247, 244, 0.88);
+.hero-minimal__assurances {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: clamp(0.55rem, 1.4vw, 0.9rem);
 }
 
-.hero-shell__feature-title {
-  display: block;
-  font-weight: 600;
-  font-size: 0.98rem;
-  color: var(--hero-foreground, #132019);
-  letter-spacing: -0.01em;
-}
-
-.hero-shell__feature p {
-  margin-top: 0.25rem;
+.hero-minimal__assurance {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: rgba(214, 229, 244, 0.84);
   font-size: 0.88rem;
-  line-height: 1.5;
-  color: var(--hero-muted, rgba(19, 32, 25, 0.7));
+  letter-spacing: 0.01em;
 }
 
-.hero-shell[data-variant='photo'] .hero-shell__feature-title,
-.hero-shell[data-variant='photo'] .hero-shell__feature p {
-  color: rgba(244, 247, 244, 0.86);
-}
+@media (max-width: 768px) {
+  .hero-minimal {
+    min-height: clamp(420px, 68vh, 520px);
+  }
 
-.hero-shell__extra {
-  margin-top: 0.5rem;
+  .hero-minimal__content {
+    gap: clamp(1.15rem, 4vw, 1.7rem);
+  }
+
+  .hero-minimal__eyebrow {
+    padding: 0.5rem 1.4rem;
+    letter-spacing: 0.22em;
+  }
+
+  .hero-minimal__frame {
+    inset: clamp(0.75rem, 4vw, 1.6rem);
+    border-radius: clamp(22px, 6vw, 36px);
+  }
 }
 
 .hero-highlight-band {

--- a/src/components/PageHero.tsx
+++ b/src/components/PageHero.tsx
@@ -1,41 +1,26 @@
 import React from 'react';
 import type { LucideIcon } from 'lucide-react';
 
-interface HeroBadge {
-  icon?: LucideIcon;
-  label: string;
-}
-
-interface HeroFeature {
-  icon?: LucideIcon;
-  title: string;
-  description?: string;
-}
-
-type HeroVariant = 'centered' | 'photo';
 type HeroAlign = 'left' | 'center';
+type HeroOverlay = 'slate' | 'spruce' | 'charcoal';
 
 interface PageHeroProps {
   title: React.ReactNode;
-  description: string;
-  backgroundImage?: string;
+  description?: React.ReactNode;
+  backgroundImage: string;
   backgroundPosition?: string;
   eyebrow?: string;
   eyebrowIcon?: LucideIcon;
   align?: HeroAlign;
-  overlay?: 'blue' | 'teal' | 'slate';
-  variant?: HeroVariant;
+  overlay?: HeroOverlay;
   actions?: React.ReactNode;
-  badges?: HeroBadge[];
-  features?: HeroFeature[];
   className?: string;
-  children?: React.ReactNode;
 }
 
-const themeMap: Record<string, string> = {
-  blue: 'spruce',
-  teal: 'evergreen',
-  slate: 'charcoal',
+const overlayToneMap: Record<HeroOverlay, string> = {
+  slate: 'slate',
+  spruce: 'spruce',
+  charcoal: 'charcoal',
 };
 
 const PageHero: React.FC<PageHeroProps> = ({
@@ -45,79 +30,37 @@ const PageHero: React.FC<PageHeroProps> = ({
   backgroundPosition = 'center',
   eyebrow,
   eyebrowIcon: EyebrowIcon,
-  align,
-  overlay = 'blue',
-  variant = 'centered',
+  align = 'center',
+  overlay = 'slate',
   actions,
-  badges,
-  features,
   className = '',
-  children,
 }) => {
-  const resolvedAlign: HeroAlign = align ?? (variant === 'centered' ? 'center' : 'left');
-  const resolvedTheme = themeMap[overlay] ?? 'spruce';
-  const showBackdrop = variant === 'photo' && backgroundImage;
+  const resolvedAlign: HeroAlign = align;
+  const overlayTone = overlayToneMap[overlay] ?? 'slate';
 
   return (
     <section
-      className={`hero-shell hero-section-spacing ${className}`.trim()}
-      data-theme={resolvedTheme}
+      className={[`hero-minimal hero-section-spacing`, className].filter(Boolean).join(' ')}
       data-align={resolvedAlign}
-      data-variant={variant}
-      data-has-image={showBackdrop ? 'true' : 'false'}
+      data-overlay={overlayTone}
     >
-      {showBackdrop && (
-        <div className="hero-shell__backdrop" aria-hidden="true">
-          <img src={backgroundImage} alt="" style={{ objectPosition: backgroundPosition }} />
-        </div>
-      )}
+      <div className="hero-minimal__media" aria-hidden="true">
+        <img src={backgroundImage} alt="" style={{ objectPosition: backgroundPosition }} />
+      </div>
+      <div className="hero-minimal__scrim" data-overlay={overlayTone} aria-hidden="true" />
+      <div className="hero-minimal__container container-max">
+        <div className="hero-minimal__content" data-align={resolvedAlign}>
+          {eyebrow && (
+            <span className="hero-minimal__eyebrow">
+              {EyebrowIcon && <EyebrowIcon className="h-4 w-4" />}
+              {eyebrow}
+            </span>
+          )}
 
-      <div className="hero-shell__container container-max px-6">
-        <div className="hero-shell__inner">
-          <div className="hero-shell__copy" data-align={resolvedAlign}>
-            {eyebrow && (
-              <span className="hero-eyebrow">
-                {EyebrowIcon && <EyebrowIcon className="h-4 w-4" />}
-                {eyebrow}
-              </span>
-            )}
+          <h1 className="hero-minimal__title">{title}</h1>
+          {description && <p className="hero-minimal__description">{description}</p>}
 
-            <h1 className="hero-shell__title">{title}</h1>
-            <p className="hero-shell__description">{description}</p>
-
-            {actions && <div className="hero-shell__actions">{actions}</div>}
-
-            {badges && badges.length > 0 && (
-              <div className="hero-shell__badges">
-                {badges.map((badge) => (
-                  <span key={badge.label} className="hero-shell__badge">
-                    {badge.icon && <badge.icon className="h-4 w-4" />}
-                    {badge.label}
-                  </span>
-                ))}
-              </div>
-            )}
-
-            {features && features.length > 0 && (
-              <div className="hero-shell__features">
-                {features.map((feature) => (
-                  <div key={feature.title} className="hero-shell__feature">
-                    {feature.icon && (
-                      <div className="hero-shell__feature-icon">
-                        <feature.icon className="h-5 w-5" />
-                      </div>
-                    )}
-                    <div className="hero-shell__feature-copy">
-                      <span className="hero-shell__feature-title">{feature.title}</span>
-                      {feature.description && <p>{feature.description}</p>}
-                    </div>
-                  </div>
-                ))}
-              </div>
-            )}
-
-            {children && <div className="hero-shell__extra">{children}</div>}
-          </div>
+          {actions && <div className="hero-minimal__actions">{actions}</div>}
         </div>
       </div>
     </section>

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -74,19 +74,14 @@ const About: React.FC = () => {
 
       <PageHero
         backgroundImage="/brisbane2.jpg"
-        variant="photo"
+        backgroundPosition="center 46%"
+        overlay="spruce"
         align="center"
         className="hero-extra-top"
         eyebrow="About MOG Cleaning"
         eyebrowIcon={Sparkles}
-        title={
-          <>
-            People-first cleaning teams
-            <br />
-            trusted across Brisbane
-          </>
-        }
-        description="We’re a Brisbane-founded team of supervisors and cleaners who deliver consistent, accountable results for the workplaces you rely on."
+        title="Meet the team behind MOG Cleaning."
+        description="Brisbane-born supervisors and cleaners who show up, communicate fast and protect every workspace."
         actions={
           <>
             <Link to="/contact" className="btn-primary">

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -162,19 +162,14 @@ const Contact: React.FC = () => {
 
       <PageHero
         backgroundImage="/images/accounting-background.jpg"
-        variant="photo"
+        backgroundPosition="center 40%"
+        overlay="charcoal"
         align="center"
         className="hero-extra-top"
         eyebrow="Contact"
         eyebrowIcon={Sparkles}
-        title={
-          <>
-            Plan your Brisbane cleaning
-            <br />
-            program with our specialists
-          </>
-        }
-        description="Share your facility details and we’ll reply within a day with pricing, onboarding steps and a dedicated supervisor."
+        title="Plan your Brisbane cleaning program with our specialists."
+        description="Tell us about your facility and we’ll reply within a day with pricing, onboarding and support."
         actions={
           <>
             <a href="tel:+61411820650" className="btn-primary">
@@ -186,10 +181,6 @@ const Contact: React.FC = () => {
             </a>
           </>
         }
-        badges={[
-          { icon: Clock, label: 'Replies within 24 hours' },
-          { icon: ShieldCheck, label: 'Police-checked crews' },
-        ]}
       />
 
       <QuoteSection

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -44,11 +44,6 @@ const Home: React.FC = () => {
     },
   ];
 
-  const heroBadges = [
-    { icon: Award, label: 'Trusted by 60+ Brisbane sites' },
-    { icon: Users, label: 'Dedicated site supervisors' },
-  ];
-
   const trustSignals = [
     {
       icon: Star,
@@ -322,32 +317,53 @@ const Home: React.FC = () => {
       />
 
       <PageHero
-        variant="photo"
+        className="hero-minimal--home"
         backgroundImage="/images/office-cleaning-background.jpg"
-        overlay="slate"
+        backgroundPosition="center 42%"
+        overlay="charcoal"
         align="center"
         eyebrow="Trusted Brisbane partner"
         eyebrowIcon={Shield}
         title={
           <>
-            Your Commercial Cleaning Partner
-            <br />
-            in Brisbane
+            <span className="hero-minimal__title-line">Your Commercial Cleaning</span>
+            <span className="hero-minimal__title-line">Partner in Brisbane</span>
           </>
         }
-        description="Tailored programs for offices, gyms and clinics — delivered by vetted crews who keep every space calm, polished and client-ready."
-        actions={
+        description={
           <>
-            <Link to="/contact" className="btn-primary">
-              Book a consultation
-            </Link>
-            <Link to="/#services" onClick={scrollToServices} className="btn-ghost">
-              Explore services
-              <ArrowRight className="h-5 w-5" />
-            </Link>
+            Specialist crews for offices, gyms and clinics who keep every shift{' '}
+            <span className="text-gradient">polished and on-brand</span>.
           </>
         }
-        badges={heroBadges}
+        actions={
+          <div className="hero-minimal__cta-group">
+            <div className="hero-minimal__cta-buttons">
+              <Link to="/contact" className="btn-primary btn-primary--elevated">
+                Book a consultation
+              </Link>
+              <Link to="/#services" onClick={scrollToServices} className="btn-ghost">
+                Explore services
+                <ArrowRight className="h-5 w-5" />
+              </Link>
+            </div>
+            <div className="hero-minimal__cta-note">
+              <Sparkles className="h-4 w-4" />
+              Site walkthrough & tailored quote within 24 hours
+            </div>
+            <div className="hero-minimal__assurances">
+              <span className="hero-minimal__assurance">
+                <Shield className="h-4 w-4" /> Fully insured crews
+              </span>
+              <span className="hero-minimal__assurance">
+                <Clock className="h-4 w-4" /> Flexible scheduling
+              </span>
+              <span className="hero-minimal__assurance">
+                <CheckCircle className="h-4 w-4" /> QA photo reports
+              </span>
+            </div>
+          </div>
+        }
       />
 
       <HeroHighlightBand items={heroHighlights} />

--- a/src/pages/Process.tsx
+++ b/src/pages/Process.tsx
@@ -125,16 +125,13 @@ const Process: React.FC = () => {
 
       <PageHero
         className="hero-extra-top"
+        backgroundImage="/brisbane.jpg"
+        backgroundPosition="center 48%"
+        overlay="spruce"
         eyebrow="Our process"
         eyebrowIcon={Sparkles}
-        title={
-          <>
-            Onboard your cleaning program
-            <br />
-            with four focused steps
-          </>
-        }
-        description="Four clear steps to scope your facility, induct your crew and keep quality measurable from day one."
+        title="A clear path to your new cleaning partner."
+        description="Four fast steps to map your site, induct your crew and keep accountability visible from day one."
         actions={
           <>
             <Link to="/contact" className="btn-primary">

--- a/src/pages/Services.tsx
+++ b/src/pages/Services.tsx
@@ -139,16 +139,13 @@ const Services: React.FC = () => {
 
       <PageHero
         className="hero-extra-top"
+        backgroundImage="/images/retail-cleaning-background.jpg"
+        backgroundPosition="center 44%"
+        overlay="charcoal"
         eyebrow="Services"
         eyebrowIcon={Sparkles}
-        title={
-          <>
-            Tailored cleaning programs
-            <br />
-            for Brisbane industries
-          </>
-        }
-        description="Select a ready-to-run program for your facility and tailor the scope, schedule and reporting cadence to match your operations."
+        title="Programs built for every Brisbane facility."
+        description="Pick a ready-to-run program, then tune the scope, schedule and reporting to your site."
         actions={
           <>
             <Link to="/contact" className="btn-primary">
@@ -159,10 +156,6 @@ const Services: React.FC = () => {
             </Link>
           </>
         }
-        badges={[
-          { icon: Shield, label: 'Compliance-ready crews' },
-          { icon: Users, label: 'Dedicated supervisors' },
-        ]}
       />
 
       <section className="section-shell">

--- a/src/pages/services/EducationCleaning.tsx
+++ b/src/pages/services/EducationCleaning.tsx
@@ -98,11 +98,6 @@ const EducationCleaning: React.FC = () => {
     { name: 'Contact Our Team', path: '/contact' },
   ];
 
-  const heroBadges = [
-    { icon: ShieldCheck, label: 'Blue Card inducted crews' },
-    { icon: CheckCircle, label: 'Low-tox, leadership-approved products' },
-  ];
-
   const heroHighlights = [
     {
       icon: GraduationCap,
@@ -195,18 +190,13 @@ const EducationCleaning: React.FC = () => {
 
       <PageHero
         backgroundImage="/images/classroom-cleaning-background.jpg"
-        variant="photo"
+        backgroundPosition="center 44%"
+        overlay="charcoal"
         align="center"
         eyebrow="Education cleaning"
         eyebrowIcon={GraduationCap}
-        title={
-          <>
-            Healthy Brisbane learning spaces
-            <br />
-            kept ready for every lesson
-          </>
-        }
-        description="Create calm classrooms and spotless amenities with child-safe cleaning programs aligned to your timetable."
+        title="Safe, inspiring campuses across Brisbane."
+        description="Create calm classrooms and spotless amenities with child-safe programs aligned to your timetable."
         actions={
           <>
             <Link to="/contact" className="btn-primary">
@@ -218,7 +208,6 @@ const EducationCleaning: React.FC = () => {
             </Link>
           </>
         }
-        badges={heroBadges}
       />
 
       <HeroHighlightBand items={heroHighlights} />

--- a/src/pages/services/FitnessCleaning.tsx
+++ b/src/pages/services/FitnessCleaning.tsx
@@ -98,11 +98,6 @@ const FitnessCleaning: React.FC = () => {
     { name: 'Read About Our Process', path: '/process' },
   ];
 
-  const heroBadges = [
-    { icon: ShieldCheck, label: 'Hospital-grade disinfectants' },
-    { icon: CheckCircle, label: 'Photo logs & QA reviews' },
-  ];
-
   const heroHighlights = [
     {
       icon: Dumbbell,
@@ -195,18 +190,13 @@ const FitnessCleaning: React.FC = () => {
 
       <PageHero
         backgroundImage="/images/fitness-cleaning-background.jpg"
-        variant="photo"
+        backgroundPosition="center 40%"
+        overlay="charcoal"
         align="center"
         eyebrow="Fitness centre cleaning"
         eyebrowIcon={Dumbbell}
-        title={
-          <>
-            Spotless Brisbane fitness studios
-            <br />
-            that keep members inspired
-          </>
-        }
-        description="Deliver a fresh, safe experience every session with routines built around your timetable, equipment mix and amenities."
+        title="Fresh, energising gyms and fitness studios."
+        description="Deliver a crisp, safe experience every session with routines shaped to your timetable and equipment mix."
         actions={
           <>
             <Link to="/contact" className="btn-primary">
@@ -218,7 +208,6 @@ const FitnessCleaning: React.FC = () => {
             </Link>
           </>
         }
-        badges={heroBadges}
       />
 
       <HeroHighlightBand items={heroHighlights} />

--- a/src/pages/services/HealthCleaning.tsx
+++ b/src/pages/services/HealthCleaning.tsx
@@ -98,11 +98,6 @@ const HealthCleaning: React.FC = () => {
     { name: 'About Our Team', path: '/about' },
   ];
 
-  const heroBadges = [
-    { icon: ShieldCheck, label: 'NSQHS & RACGP aligned' },
-    { icon: CheckCircle, label: 'Audit-ready reporting packs' },
-  ];
-
   const heroHighlights = [
     {
       icon: Heart,
@@ -195,18 +190,13 @@ const HealthCleaning: React.FC = () => {
 
       <PageHero
         backgroundImage="/images/medical-cleaning-background.jpg"
-        variant="photo"
+        backgroundPosition="center 38%"
+        overlay="charcoal"
         align="center"
         eyebrow="Medical facility cleaning"
         eyebrowIcon={Heart}
-        title={
-          <>
-            Medical-grade Brisbane clinics
-            <br />
-            maintained with clinical care
-          </>
-        }
-        description="Protect patients, practitioners and accreditation with infection-control trained crews and transparent reporting."
+        title="Clinical-grade cleaning for Brisbane practices."
+        description="Protect patients, practitioners and accreditation with infection-control crews and transparent reporting."
         actions={
           <>
             <Link to="/contact" className="btn-primary">
@@ -218,7 +208,6 @@ const HealthCleaning: React.FC = () => {
             </Link>
           </>
         }
-        badges={heroBadges}
       />
 
       <HeroHighlightBand items={heroHighlights} />

--- a/src/pages/services/HospitalityCleaning.tsx
+++ b/src/pages/services/HospitalityCleaning.tsx
@@ -98,11 +98,6 @@ const HospitalityCleaning: React.FC = () => {
     { name: 'About MOG Cleaning', path: '/about' },
   ];
 
-  const heroBadges = [
-    { icon: ShieldCheck, label: 'Food-safe, HACCP aware crews' },
-    { icon: CheckCircle, label: 'Photo reports every shift' },
-  ];
-
   const heroHighlights = [
     {
       icon: Hotel,
@@ -195,18 +190,13 @@ const HospitalityCleaning: React.FC = () => {
 
       <PageHero
         backgroundImage="/images/hotel-cleaning-background.jpg"
-        variant="photo"
+        backgroundPosition="center 45%"
+        overlay="charcoal"
         align="center"
         eyebrow="Hospitality cleaning"
         eyebrowIcon={Hotel}
-        title={
-          <>
-            Hospitality venues in Brisbane
-            <br />
-            kept guest-ready every night
-          </>
-        }
-        description="Deliver immaculate rooms, dining spaces and event venues with crews who work around every service window."
+        title="Immaculate venues ready for every guest."
+        description="Deliver flawless rooms, dining spaces and event venues with crews who flex to every service window."
         actions={
           <>
             <Link to="/contact" className="btn-primary">
@@ -218,7 +208,6 @@ const HospitalityCleaning: React.FC = () => {
             </Link>
           </>
         }
-        badges={heroBadges}
       />
 
       <HeroHighlightBand items={heroHighlights} />

--- a/src/pages/services/OfficesCleaning.tsx
+++ b/src/pages/services/OfficesCleaning.tsx
@@ -99,11 +99,6 @@ const OfficesCleaning: React.FC = () => {
     { name: 'About MOG Cleaning', path: '/about' },
   ];
 
-  const heroBadges = [
-    { icon: ShieldCheck, label: 'Inducted & police-checked crews' },
-    { icon: CheckCircle, label: 'QA inspections with photo reports' },
-  ];
-
   const heroHighlights = [
     {
       icon: Users,
@@ -196,18 +191,13 @@ const OfficesCleaning: React.FC = () => {
 
       <PageHero
         backgroundImage="/images/office-cleaning-background.jpg"
-        variant="photo"
+        backgroundPosition="center 42%"
+        overlay="charcoal"
         align="center"
         eyebrow="Office cleaning"
         eyebrowIcon={Building2}
-        title={
-          <>
-            Polished Brisbane workplaces
-            <br />
-            maintained by dedicated crews
-          </>
-        }
-        description="Keep executive suites, meeting rooms and shared spaces inspection-ready with a program built for your building and schedule."
+        title="Dependable cleaning for Brisbane workplaces."
+        description="Keep suites, meeting rooms and breakout spaces inspection-ready with a program tuned to your building."
         actions={
           <>
             <Link to="/contact" className="btn-primary">
@@ -219,7 +209,6 @@ const OfficesCleaning: React.FC = () => {
             </Link>
           </>
         }
-        badges={heroBadges}
       />
 
       <HeroHighlightBand items={heroHighlights} />

--- a/src/pages/services/RetailCleaning.tsx
+++ b/src/pages/services/RetailCleaning.tsx
@@ -98,11 +98,6 @@ const RetailCleaning: React.FC = () => {
     { name: 'Book a Strategy Session', path: '/contact' },
   ];
 
-  const heroBadges = [
-    { icon: ShieldCheck, label: 'Centre-compliant presentation' },
-    { icon: CheckCircle, label: 'VM-friendly detailing crews' },
-  ];
-
   const heroHighlights = [
     {
       icon: ShoppingBag,
@@ -195,18 +190,13 @@ const RetailCleaning: React.FC = () => {
 
       <PageHero
         backgroundImage="/images/retail-cleaning-background.jpg"
-        variant="photo"
+        backgroundPosition="center 46%"
+        overlay="charcoal"
         align="center"
         eyebrow="Retail cleaning"
         eyebrowIcon={ShoppingBag}
-        title={
-          <>
-            Retail experiences across Brisbane
-            <br />
-            presented with immaculate detail
-          </>
-        }
-        description="Maintain showroom shine and guest-ready amenities with crews who flex around product launches and trade windows."
+        title="Spotless retail spaces that convert every visit."
+        description="Maintain showroom shine and guest-ready amenities with crews who adapt around launches and trade."
         actions={
           <>
             <Link to="/contact" className="btn-primary">
@@ -218,7 +208,6 @@ const RetailCleaning: React.FC = () => {
             </Link>
           </>
         }
-        badges={heroBadges}
       />
 
       <HeroHighlightBand items={heroHighlights} />


### PR DESCRIPTION
## Summary
- tighten the hero imagery treatment with a closer zoom and enforce a two-line clamp for descriptions
- refresh hero subtext across home, core, and service pages to deliver punchier two-line messaging
- align every hero background position so photography stays consistently close-up across the site

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1d08583948327bb737a7fb7d62937