### PR TITLE
Refresh service card layout for a minimal presentation

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -575,54 +575,38 @@ h6 {
 
 .service-card {
   position: relative;
-  display: block;
+  display: flex;
+  flex-direction: column;
   height: 100%;
+  overflow: hidden;
+  border-radius: clamp(26px, 3vw, 32px);
+  border: 1px solid rgba(8, 33, 57, 0.08);
+  background: linear-gradient(170deg, rgba(255, 255, 255, 0.96), rgba(242, 248, 253, 0.92));
+  box-shadow: 0 26px 70px -46px rgba(6, 27, 46, 0.55);
   text-decoration: none;
   color: inherit;
+  transition: transform 0.4s ease, box-shadow 0.4s ease, border-color 0.4s ease;
 }
 
 .service-card:focus-visible {
   outline: none;
-}
-
-.service-card__frame {
-  position: relative;
-  height: 100%;
-  border-radius: clamp(28px, 3vw, 34px);
-  padding: 1.2px;
-  background: linear-gradient(140deg, rgba(255, 255, 255, 0.65), rgba(13, 161, 225, 0.38));
-  transition: transform 0.35s ease, box-shadow 0.35s ease;
-}
-
-.service-card__surface {
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-  border-radius: inherit;
-  overflow: hidden;
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(243, 248, 254, 0.9));
-  box-shadow: 0 30px 70px -46px rgba(7, 30, 52, 0.65);
+  transform: translateY(-6px);
+  border-color: rgba(13, 161, 225, 0.46);
+  box-shadow: 0 36px 90px -40px rgba(5, 31, 52, 0.65);
 }
 
 .service-card__visual {
   position: relative;
-  overflow: hidden;
   aspect-ratio: 4 / 3;
-  background: #0a1e2d;
+  overflow: hidden;
+  background: linear-gradient(135deg, rgba(10, 34, 51, 0.85), rgba(10, 34, 51, 0.35));
+  isolation: isolate;
 }
 
 @media (min-width: 768px) {
   .service-card__visual {
-    aspect-ratio: 16 / 10;
+    aspect-ratio: 16 / 9;
   }
-}
-
-.service-card__image {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  transform: scale(1.02);
-  transition: transform 0.6s ease;
 }
 
 .service-card__visual::after {
@@ -630,45 +614,96 @@ h6 {
   position: absolute;
   inset: 0;
   background: linear-gradient(185deg, rgba(4, 21, 33, 0.1), rgba(4, 21, 33, 0.45));
-  opacity: 0.85;
-  transition: opacity 0.45s ease;
+  opacity: 0.55;
+  transition: opacity 0.6s ease;
+  mix-blend-mode: multiply;
 }
 
-.service-card__label {
+.service-card__image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transform: scale(1.06);
+  filter: saturate(1.05);
+  transition: transform 0.6s ease, filter 0.6s ease;
+}
+
+.service-card__badge {
   position: absolute;
-  left: 1.5rem;
-  bottom: 1.5rem;
+  left: clamp(1.2rem, 2vw, 1.75rem);
+  bottom: clamp(1.2rem, 2vw, 1.75rem);
   display: inline-flex;
   align-items: center;
-  gap: 0.65rem;
-  padding: 0.55rem 1.35rem;
+  gap: 0.6rem;
+  padding: 0.5rem 1.2rem;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.92);
-  color: #062233;
-  font-size: 0.78rem;
-  font-weight: 700;
-  letter-spacing: 0.16em;
+  background: rgba(255, 255, 255, 0.9);
+  color: #052036;
+  font-size: 0.74rem;
+  font-weight: 600;
+  letter-spacing: 0.18em;
   text-transform: uppercase;
-  box-shadow: 0 16px 32px -22px rgba(8, 24, 37, 0.6);
+  box-shadow: 0 18px 36px -26px rgba(5, 24, 38, 0.65);
 }
 
-.service-card__content {
-  position: relative;
+.service-card__badge svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+.service-card__body {
   display: flex;
   flex-direction: column;
-  gap: 0.9rem;
-  padding: clamp(1.9rem, 2vw + 1.3rem, 2.6rem);
+  gap: clamp(0.9rem, 1.5vw, 1.35rem);
+  padding: clamp(1.9rem, 2.4vw + 1rem, 2.7rem);
+}
+
+.service-card__eyebrow {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: #0da1e1;
 }
 
 .service-card__title {
-  font-size: clamp(1.35rem, 0.6vw + 1.3rem, 1.55rem);
+  font-size: clamp(1.45rem, 0.6vw + 1.35rem, 1.8rem);
   font-weight: 700;
   color: #0a2233;
 }
 
 .service-card__description {
-  color: rgba(15, 36, 52, 0.75);
-  line-height: 1.6;
+  color: rgba(9, 32, 53, 0.72);
+  line-height: 1.7;
+}
+
+.service-card__list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  color: rgba(9, 32, 53, 0.66);
+}
+
+.service-card__list li {
+  position: relative;
+  padding-left: 1.55rem;
+  font-size: 0.95rem;
+  line-height: 1.55;
+}
+
+.service-card__list li::before {
+  content: '';
+  position: absolute;
+  top: 0.55rem;
+  left: 0;
+  width: 0.45rem;
+  height: 0.45rem;
+  border-radius: 999px;
+  background: #0da1e1;
+  box-shadow: 0 0 0 6px rgba(13, 161, 225, 0.12);
 }
 
 .service-card__cta {
@@ -677,38 +712,35 @@ h6 {
   gap: 0.55rem;
   margin-top: auto;
   font-weight: 600;
-  color: #0da1e1;
-  transition: color 0.3s ease;
+  color: #052036;
+  transition: color 0.35s ease;
 }
 
 .service-card__cta svg {
-  transition: transform 0.3s ease;
+  transition: transform 0.35s ease;
 }
 
-.service-card:hover .service-card__frame,
-.service-card:focus-visible .service-card__frame {
-  transform: translateY(-8px);
-  box-shadow: 0 36px 88px -42px rgba(6, 28, 47, 0.7);
+.service-card:hover {
+  transform: translateY(-10px);
+  border-color: rgba(13, 161, 225, 0.38);
+  box-shadow: 0 40px 96px -44px rgba(6, 30, 52, 0.65);
 }
 
-.service-card:hover .service-card__image,
-.service-card:focus-visible .service-card__image {
-  transform: scale(1.08);
+.service-card:hover .service-card__image {
+  transform: scale(1.12);
+  filter: saturate(1.12);
 }
 
-.service-card:hover .service-card__visual::after,
-.service-card:focus-visible .service-card__visual::after {
-  opacity: 0.72;
+.service-card:hover .service-card__visual::after {
+  opacity: 0.38;
 }
 
-.service-card:hover .service-card__cta,
-.service-card:focus-visible .service-card__cta {
-  color: #0786c5;
+.service-card:hover .service-card__cta {
+  color: #0da1e1;
 }
 
-.service-card:hover .service-card__cta svg,
-.service-card:focus-visible .service-card__cta svg {
-  transform: translateX(4px);
+.service-card:hover .service-card__cta svg {
+  transform: translateX(6px);
 }
 
 .process-step {

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -428,36 +428,28 @@ const Home: React.FC = () => {
           <div className="grid grid-cols-1 gap-8 md:grid-cols-2 xl:grid-cols-3">
             {services.map((service) => (
               <Link key={service.name} to={service.path} className="service-card group">
-                <div className="service-card__frame">
-                  <div className="service-card__surface">
-                    <div className="service-card__visual">
-                      <img
-                        src={service.image}
-                        alt={`${service.name} cleaning in Brisbane`}
-                        className="service-card__image"
-                        loading="lazy"
-                        decoding="async"
-                      />
-                      <span className="service-card__label">
-                        <service.icon className="h-4 w-4" />
-                        {service.name}
-                      </span>
-                    </div>
-                    <div className="service-card__content">
-                      <h3 className="service-card__title">{service.name}</h3>
-                      <p className="service-card__description">{service.description}</p>
-                      <span className="service-card__cta">
-                        Explore program
-                        <ArrowRight className="h-4 w-4" />
-                      </span>
-                    </div>
-                  </div>
+                <div className="service-card__visual">
+                  <img
+                    src={service.image}
+                    alt={`${service.name} cleaning in Brisbane`}
+                    className="service-card__image"
+                    loading="lazy"
+                    decoding="async"
+                  />
+                  <span className="service-card__badge">
+                    <service.icon className="h-4 w-4" aria-hidden="true" />
+                    {service.name}
+                  </span>
                 </div>
-                <p className="text-lg text-jet leading-relaxed">{service.description}</p>
-                <span className="link-arrow">
-                  View program
-                  <ArrowRight className="h-4 w-4" />
-                </span>
+                <div className="service-card__body">
+                  <span className="service-card__eyebrow">Sector program</span>
+                  <h3 className="service-card__title">{service.name}</h3>
+                  <p className="service-card__description">{service.description}</p>
+                  <span className="service-card__cta">
+                    Explore program
+                    <ArrowRight className="h-4 w-4" aria-hidden="true" />
+                  </span>
+                </div>
               </Link>
             ))}
           </div>

--- a/src/pages/Services.tsx
+++ b/src/pages/Services.tsx
@@ -170,33 +170,33 @@ const Services: React.FC = () => {
           <div className="grid grid-cols-1 gap-8 md:grid-cols-2">
             {services.map((service) => (
               <Link key={service.name} to={service.path} className="service-card group">
-                <div className="relative overflow-hidden rounded-3xl">
+                <div className="service-card__visual">
                   <img
                     src={service.image}
                     alt={`${service.name} cleaning in Brisbane`}
-                    className="h-48 w-full object-cover transition duration-500 group-hover:scale-105"
+                    className="service-card__image"
                     loading="lazy"
                     decoding="async"
                   />
-                  <div className="absolute inset-0 bg-gradient-to-t from-[#051423]/80 via-[#051423]/20 to-transparent" aria-hidden="true" />
-                  <div className="absolute bottom-4 left-4 inline-flex items-center gap-2 rounded-full bg-white/85 px-4 py-2 text-xs font-semibold uppercase tracking-[0.28em] text-charcoal/70 shadow">
-                    <service.icon className="h-4 w-4" />
+                  <span className="service-card__badge">
+                    <service.icon className="h-4 w-4" aria-hidden="true" />
                     {service.name}
-                  </div>
+                  </span>
                 </div>
-                <p className="text-lg text-jet leading-relaxed">{service.description}</p>
-                <ul className="space-y-2 text-jet/70 text-sm">
-                  {service.highlights.map((highlight) => (
-                    <li key={highlight} className="flex items-start gap-2">
-                      <span className="mt-2 h-1.5 w-1.5 rounded-full bg-celestial-blue-1"></span>
-                      <span>{highlight}</span>
-                    </li>
-                  ))}
-                </ul>
-                <span className="link-arrow">
-                  View program
-                  <ArrowRight className="h-4 w-4" />
-                </span>
+                <div className="service-card__body">
+                  <span className="service-card__eyebrow">Program overview</span>
+                  <h3 className="service-card__title">{service.name}</h3>
+                  <p className="service-card__description">{service.description}</p>
+                  <ul className="service-card__list">
+                    {service.highlights.map((highlight) => (
+                      <li key={highlight}>{highlight}</li>
+                    ))}
+                  </ul>
+                  <span className="service-card__cta">
+                    Explore program
+                    <ArrowRight className="h-4 w-4" aria-hidden="true" />
+                  </span>
+                </div>
               </Link>
             ))}
           </div>


### PR DESCRIPTION
## Summary
- rebuild the service card markup on the home and services pages around a single minimalist layout
- restyle the shared service card CSS with softer gradients, refined badges, and improved hover/focus feedback
- apply structured highlight list styling within services cards for clearer program details

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2211df6808327910bb9001d23d237