### PR TITLE
Refocus service detail pages around conversion journey

### DIFF
--- a/src/components/StickyCTABar.tsx
+++ b/src/components/StickyCTABar.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+interface StickyCTABarProps {
+  title: string;
+  description?: string;
+  primaryLabel: string;
+  primaryHref: string;
+  secondaryLabel?: string;
+  secondaryHref?: string;
+}
+
+const StickyCTABar: React.FC<StickyCTABarProps> = ({
+  title,
+  description,
+  primaryLabel,
+  primaryHref,
+  secondaryLabel,
+  secondaryHref,
+}) => {
+  const renderAction = (label: string, href: string, variant: 'primary' | 'secondary') => {
+    const baseClasses =
+      variant === 'primary'
+        ? 'inline-flex items-center justify-center rounded-full bg-celestial-blue-1 px-6 py-3 text-sm font-semibold text-white shadow-lg transition hover:bg-celestial-blue-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-celestial-blue-1/60 focus-visible:ring-offset-2'
+        : 'inline-flex items-center justify-center rounded-full border border-white/30 bg-transparent px-6 py-3 text-sm font-semibold text-white transition hover:border-white focus:outline-none focus-visible:ring-2 focus-visible:ring-white/50 focus-visible:ring-offset-2';
+
+    if (href.startsWith('/')) {
+      return (
+        <Link to={href} className={baseClasses}>
+          {label}
+        </Link>
+      );
+    }
+
+    return (
+      <a href={href} className={baseClasses}>
+        {label}
+      </a>
+    );
+  };
+
+  return (
+    <div className="fixed inset-x-0 bottom-0 z-40 border-t border-white/20 bg-charcoal/95 py-4 shadow-lg backdrop-blur">
+      <div className="container-max mx-auto flex flex-col items-center gap-3 px-4 text-center text-white sm:flex-row sm:justify-between sm:text-left">
+        <div>
+          <p className="text-sm font-semibold uppercase tracking-[0.18em] text-white/70">{title}</p>
+          {description ? <p className="mt-1 text-base text-white/80">{description}</p> : null}
+        </div>
+        <div className="flex flex-col gap-3 sm:flex-row">
+          {renderAction(primaryLabel, primaryHref, 'primary')}
+          {secondaryLabel && secondaryHref
+            ? renderAction(secondaryLabel, secondaryHref, 'secondary')
+            : null}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default StickyCTABar;

--- a/src/pages/services/EducationCleaning.tsx
+++ b/src/pages/services/EducationCleaning.tsx
@@ -20,6 +20,7 @@ import PageHero from '../../components/PageHero';
 import QuoteSection from '../../components/QuoteSection';
 import HeroHighlightBand from '../../components/HeroHighlightBand';
 import HowItWorks from '../../components/HowItWorks';
+import StickyCTABar from '../../components/StickyCTABar';
 
 const EducationCleaning: React.FC = () => {
   const inclusions = [
@@ -231,30 +232,30 @@ const EducationCleaning: React.FC = () => {
   };
 
   return (
-    <div>
+    <div className="pb-32">
       <SEO
         title={pageTitle}
         description={pageDescription}
         type="service"
-        image="/images/classroom-cleaning-background.jpg"
-        imageAlt="Cleaner tidying a Brisbane classroom"
-        keywords={['school cleaning Brisbane', 'education cleaners', 'childcare cleaning services']}
+        image="/images/school-cleaning-background.jpg"
+        imageAlt="Brisbane school classroom being cleaned"
+        keywords={['school cleaning Brisbane', 'education cleaning services', 'childcare cleaners Brisbane']}
         jsonLd={[breadcrumbSchema, serviceSchema]}
       />
 
       <PageHero
-        backgroundImage="/images/classroom-cleaning-background.jpg"
-        backgroundPosition="center 44%"
+        backgroundImage="/images/school-cleaning-background.jpg"
+        backgroundPosition="center"
         overlay="charcoal"
         align="center"
         eyebrow="Education cleaning"
         eyebrowIcon={GraduationCap}
-        title="Learning environments that stay healthy and welcoming."
-        description="Reliable crews care for classrooms, playgrounds and specialist facilities with child-safe products."
+        title="Show parents and staff a campus that feels cared for."
+        description="Specialist education cleaners who protect student wellbeing, support your team and keep every wing presentation ready."
         actions={
           <>
             <Link to="/contact" className="btn-primary">
-              Get a quote
+              Book a campus walkthrough
             </Link>
             <a href="tel:+61411820650" className="btn-secondary">
               Call 0411 820 650
@@ -265,49 +266,13 @@ const EducationCleaning: React.FC = () => {
 
       <HeroHighlightBand items={heroHighlights} />
 
-      <section className="section-shell section-shell--muted" id="schedule">
-        <div className="container-max mx-auto grid gap-10 lg:grid-cols-[1.15fr_1fr] lg:items-center">
-          <div className="space-y-6">
-            <div className="section-heading" data-align="left">
-              <span className="section-heading__eyebrow">Term-time rhythm</span>
-              <h2 className="section-heading__title">Cleaning windows tuned to the school day</h2>
-              <p className="section-heading__description">
-                Rosters are planned around bells, assemblies and extracurricular bookings so every area feels freshly reset when students arrive.
-              </p>
-            </div>
-            <ul className="space-y-4 text-jet/80">
-              <li className="flex items-start gap-3">
-                <CheckCircle className="mt-1 h-5 w-5 text-celestial-blue-1" />
-                <span>Dedicated leads for junior, senior and specialist precincts with tailored scopes.</span>
-              </li>
-              <li className="flex items-start gap-3">
-                <CheckCircle className="mt-1 h-5 w-5 text-celestial-blue-1" />
-                <span>Live communication channel when repairs, spills or outbreaks are identified.</span>
-              </li>
-              <li className="flex items-start gap-3">
-                <CheckCircle className="mt-1 h-5 w-5 text-celestial-blue-1" />
-                <span>Additional crews allocated for open days, sports carnivals and exam blocks.</span>
-              </li>
-            </ul>
-          </div>
-          <div className="grid gap-4 sm:grid-cols-2">
-            {scheduleHighlights.map((item) => (
-              <div key={item.label} className="glass-panel h-full space-y-2 rounded-3xl p-6" data-variant="frost">
-                <p className="text-sm font-semibold uppercase tracking-wide text-celestial-blue-1/70">{item.label}</p>
-                <p className="text-charcoal text-lg font-semibold">{item.description}</p>
-              </div>
-            ))}
-          </div>
-        </div>
-      </section>
-
       <section className="section-shell" id="pain-points">
         <div className="container-max mx-auto">
           <div className="section-heading">
             <span className="section-heading__eyebrow">Why schools switch</span>
-            <h2 className="section-heading__title">Cleaning frustrations we eliminate</h2>
+            <h2 className="section-heading__title">When cleaning slips, your community notices</h2>
             <p className="section-heading__description">
-              From childcare centres to universities, education leaders choose MOG Cleaning when presentation, hygiene and communication need a reset.
+              Principals and business managers call us when teachers arrive to messy classrooms or playgrounds look neglected. We bring order back fast.
             </p>
           </div>
           <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
@@ -324,65 +289,44 @@ const EducationCleaning: React.FC = () => {
         </div>
       </section>
 
-      <section className="section-shell" id="solution">
-        <div className="container-max mx-auto grid gap-12 lg:grid-cols-2 lg:items-center">
-          <div className="glass-panel" data-variant="frost">
-            <img
-              src="/images/classroom-cleaning-background.jpg"
-              alt="Cleaner sanitising classroom desks"
-              className="h-full w-full rounded-[32px] object-cover"
-              loading="lazy"
-              decoding="async"
-            />
-          </div>
+      <section className="section-shell" id="plan">
+        <div className="container-max mx-auto grid gap-12 lg:grid-cols-[1.15fr_1fr] lg:items-center">
           <div className="space-y-6">
             <div className="section-heading" data-align="left">
-              <span className="section-heading__eyebrow">Our approach</span>
-              <h2 className="section-heading__title">A structured routine for every campus zone</h2>
+              <span className="section-heading__eyebrow">Your plan</span>
+              <h2 className="section-heading__title">A term-by-term rhythm parents can see</h2>
               <p className="section-heading__description">
-                We combine daily presentation, outbreak response and deep cleaning schedules so classrooms, halls and playgrounds stay ready for learning.
+                We align rosters with bell times, after-hours events and holiday breaks. Within the first month you receive a campus-wide checklist and proactive communication channel.
               </p>
             </div>
             <ul className="space-y-4 text-jet/80">
               <li className="flex items-start gap-3">
-                <CheckCircle className="h-5 w-5 text-celestial-blue-1" />
-                <span>Detailed scopes for classrooms, specialist rooms and administrative areas.</span>
+                <CheckCircle className="mt-1 h-5 w-5 text-celestial-blue-1" />
+                <span>On-site walkthrough, safety induction and scope build completed in week one.</span>
               </li>
               <li className="flex items-start gap-3">
-                <CheckCircle className="h-5 w-5 text-celestial-blue-1" />
-                <span>Holiday deep cleans cover floors, windows, carpets and high dusting.</span>
+                <Users className="mt-1 h-5 w-5 text-celestial-blue-1" />
+                <span>Dedicated crew leaders for each precinct so classrooms, amenities and grounds stay aligned.</span>
               </li>
               <li className="flex items-start gap-3">
-                <CheckCircle className="h-5 w-5 text-celestial-blue-1" />
-                <span>Rapid communication when maintenance issues or incidents are spotted.</span>
+                <Clock className="mt-1 h-5 w-5 text-celestial-blue-1" />
+                <span>Holiday deep-clean programs and rapid outbreak response without disrupting learning.</span>
               </li>
             </ul>
             <div className="flex flex-wrap gap-4">
               <Link to="/contact" className="btn-primary">
-                Book a school walkthrough
+                Plan my walkthrough
               </Link>
               <a href="tel:+61411820650" className="btn-secondary">
-                Call 0411 820 650
+                Talk to an education lead
               </a>
             </div>
           </div>
-        </div>
-      </section>
-
-      <section className="section-shell section-shell--muted" id="campus-zones">
-        <div className="container-max mx-auto">
-          <div className="section-heading">
-            <span className="section-heading__eyebrow">Campus coverage</span>
-            <h2 className="section-heading__title">Each learning zone gets its own playbook</h2>
-            <p className="section-heading__description">
-              Crew rotations are structured by zone so classrooms, grounds and specialist facilities all receive the attention they need.
-            </p>
-          </div>
-          <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
-            {campusZones.map((zone) => (
-              <div key={zone.title} className="rounded-[32px] border border-white/40 bg-white p-8 shadow-sm">
-                <h3 className="text-2xl font-semibold text-charcoal">{zone.title}</h3>
-                <p className="mt-3 text-jet/80 leading-relaxed">{zone.copy}</p>
+          <div className="grid gap-4 sm:grid-cols-3">
+            {scheduleHighlights.map((highlight) => (
+              <div key={highlight.label} className="rounded-[32px] border border-white/40 bg-white p-6 text-center shadow-sm">
+                <h3 className="text-lg font-semibold text-charcoal">{highlight.label}</h3>
+                <p className="mt-2 text-sm leading-relaxed text-jet/80">{highlight.description}</p>
               </div>
             ))}
           </div>
@@ -390,31 +334,64 @@ const EducationCleaning: React.FC = () => {
       </section>
 
       <HowItWorks
-        eyebrow="Implementation"
-        title="Four steps to launch your education cleaning program"
-        description="A guided onboarding keeps school leadership confident from the first bell."
+        eyebrow="How onboarding works"
+        title="Four steps to a consistently clean campus"
+        description="Every education partner follows our proven path, giving you visibility before the first bell of term."
       />
 
+      <section className="section-shell section-shell--muted" id="campus-zones">
+        <div className="container-max mx-auto">
+          <div className="section-heading">
+            <span className="section-heading__eyebrow">Campus coverage</span>
+            <h2 className="section-heading__title">Programs tailored to every zone</h2>
+            <p className="section-heading__description">
+              From early learning rooms to performing arts centres, every area receives its own checklist and accountable crew.
+            </p>
+          </div>
+          <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+            {campusZones.map((zone) => (
+              <div key={zone.title} className="rounded-[32px] bg-white p-8 shadow-sm">
+                <h3 className="text-2xl font-semibold text-charcoal">{zone.title}</h3>
+                <p className="mt-3 leading-relaxed text-jet/80">{zone.copy}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="section-shell" id="testimonials">
+        <div className="container-max mx-auto">
+          <div className="section-heading">
+            <span className="section-heading__eyebrow">Proof for your board</span>
+            <h2 className="section-heading__title">Queensland schools that rely on us</h2>
+            <p className="section-heading__description">
+              Hear how education leaders describe the uplift in presentation, communication and parent confidence.
+            </p>
+          </div>
+          <TestimonialCarousel testimonials={testimonials} className="mx-auto max-w-4xl" />
+        </div>
+      </section>
+
       <QuoteSection
-        eyebrow="Start planning"
-        title="Request your school cleaning proposal"
-        description="Share your campus size, learning precincts and key concerns. Our proposals outline labour allocations, inspection cadence and onboarding timelines."
+        eyebrow="Start your program"
+        title="Request your education cleaning proposal"
+        description="Share your enrolments, number of buildings and current challenges. We’ll prepare a tailored scope, onboarding timeline and pricing within 24 hours."
         bullets={[
-          'Child-safe, low-tox products',
-          'Holiday deep clean scheduling',
-          'Dedicated supervisor communication',
+          'Child-safe products and induction-ready teams',
+          'Term-by-term scheduling with event support',
+          'Transparent reporting and parent-ready comms',
         ]}
-        formTitle="Tell us about your school"
-        formSubtitle="An education specialist will respond within one business day."
+        formTitle="Tell us about your campus"
+        formSubtitle="Your dedicated education contact will reach out within one business day."
       />
 
       <section className="section-shell" id="benefits">
         <div className="container-max mx-auto">
           <div className="section-heading">
-            <span className="section-heading__eyebrow">Benefits</span>
-            <h2 className="section-heading__title">Why education leaders choose MOG Cleaning</h2>
+            <span className="section-heading__eyebrow">Why schools stay</span>
+            <h2 className="section-heading__title">Outcomes for your staff, students and families</h2>
             <p className="section-heading__description">
-              We help facilities teams deliver safe, welcoming environments that showcase your school’s standards.
+              Consistent presentation, safer environments and streamlined communication keep your community confident.
             </p>
           </div>
           <div className="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-4">
@@ -424,7 +401,7 @@ const EducationCleaning: React.FC = () => {
                   <benefit.icon className="h-7 w-7" />
                 </div>
                 <h3 className="text-xl font-semibold text-charcoal">{benefit.title}</h3>
-                <p className="text-jet/80 leading-relaxed">{benefit.description}</p>
+                <p className="leading-relaxed text-jet/80">{benefit.description}</p>
               </div>
             ))}
           </div>
@@ -437,29 +414,16 @@ const EducationCleaning: React.FC = () => {
             <span className="section-heading__eyebrow">What’s included</span>
             <h2 className="section-heading__title">Education cleaning checklist</h2>
             <p className="section-heading__description">
-              Every service is backed by documented checklists covering classrooms, common areas and outdoor spaces.
+              Every visit follows a documented scope so classrooms, grounds and amenities stay spotless without reminders.
             </p>
           </div>
           <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
             {inclusions.map((inclusion) => (
               <div key={inclusion} className="service-item p-6">
-                <p className="text-charcoal font-medium">{inclusion}</p>
+                <p className="font-medium text-charcoal">{inclusion}</p>
               </div>
             ))}
           </div>
-        </div>
-      </section>
-
-      <section className="section-shell" id="testimonials">
-        <div className="container-max mx-auto">
-          <div className="section-heading">
-            <span className="section-heading__eyebrow">Results</span>
-            <h2 className="section-heading__title">What Brisbane education leaders say</h2>
-            <p className="section-heading__description">
-              Hear from principals and facility managers who rely on MOG Cleaning to keep students safe and impressed.
-            </p>
-          </div>
-          <TestimonialCarousel testimonials={testimonials} className="mx-auto max-w-4xl" />
         </div>
       </section>
 
@@ -467,22 +431,22 @@ const EducationCleaning: React.FC = () => {
         <div className="container-max mx-auto">
           <div className="section-heading">
             <span className="section-heading__eyebrow">FAQs</span>
-            <h2 className="section-heading__title">Education cleaning questions answered</h2>
+            <h2 className="section-heading__title">Education cleaning FAQs</h2>
             <p className="section-heading__description">
-              Get clarity on scheduling, safety checks and onboarding before you book your campus walkthrough.
+              Understand how we work around bells, events and compliance requirements before you commit.
             </p>
           </div>
-          <FAQAccordion faqs={faqs} className="max-w-4xl mx-auto" />
+          <FAQAccordion faqs={faqs} className="mx-auto max-w-4xl" />
         </div>
       </section>
 
       <section className="section-shell section-shell--muted" id="related">
         <div className="container-max mx-auto">
           <div className="section-heading">
-            <span className="section-heading__eyebrow">Explore more programs</span>
-            <h2 className="section-heading__title">Consistent standards across your facilities</h2>
+            <span className="section-heading__eyebrow">Need something else?</span>
+            <h2 className="section-heading__title">Explore other services</h2>
             <p className="section-heading__description">
-              Extend MOG Cleaning across clinics, hospitality venues or administration offices for a unified experience.
+              From healthcare to hospitality, we bring the same responsive support to every industry we serve.
             </p>
           </div>
           <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
@@ -503,11 +467,11 @@ const EducationCleaning: React.FC = () => {
         <div className="container-max mx-auto text-center">
           <div className="mx-auto max-w-3xl space-y-6">
             <span className="pill-chip bg-white/10 text-white">
-              <Sparkles className="h-4 w-4" /> Trusted by Brisbane schools
+              <Sparkles className="h-4 w-4" /> Trusted by Queensland schools
             </span>
-            <h2 className="section-heading__title text-white">Ready to upgrade your campus presentation?</h2>
+            <h2 className="section-heading__title text-white">Ready to impress families this term?</h2>
             <p className="section-heading__description text-white/80">
-              Schedule a walkthrough and receive a detailed cleaning proposal within 24 hours.
+              Book a walkthrough and receive a tailored scope, pricing and onboarding plan within 24 hours.
             </p>
             <div className="flex flex-col items-center justify-center gap-4 sm:flex-row sm:gap-6">
               <Link to="/contact" className="btn-primary">
@@ -520,6 +484,15 @@ const EducationCleaning: React.FC = () => {
           </div>
         </div>
       </section>
+
+      <StickyCTABar
+        title="Give your campus a fresh start"
+        description="Book a walkthrough to lock in a tailored education cleaning program."
+        primaryLabel="Book my walkthrough"
+        primaryHref="/contact"
+        secondaryLabel="Call 0411 820 650"
+        secondaryHref="tel:+61411820650"
+      />
     </div>
   );
 };

--- a/src/pages/services/FitnessCleaning.tsx
+++ b/src/pages/services/FitnessCleaning.tsx
@@ -19,6 +19,7 @@ import PageHero from '../../components/PageHero';
 import QuoteSection from '../../components/QuoteSection';
 import HeroHighlightBand from '../../components/HeroHighlightBand';
 import HowItWorks from '../../components/HowItWorks';
+import StickyCTABar from '../../components/StickyCTABar';
 
 const FitnessCleaning: React.FC = () => {
   const inclusions = [
@@ -230,30 +231,30 @@ const FitnessCleaning: React.FC = () => {
   };
 
   return (
-    <div>
+    <div className="pb-32">
       <SEO
         title={pageTitle}
         description={pageDescription}
         type="service"
         image="/images/fitness-cleaning-background.jpg"
-        imageAlt="Cleaner sanitising gym equipment in Brisbane"
-        keywords={['gym cleaning Brisbane', 'fitness centre cleaners', 'studio cleaning services']}
+        imageAlt="Clean Brisbane gym with sanitised equipment"
+        keywords={['gym cleaning Brisbane', 'fitness centre cleaners', 'health club cleaning services']}
         jsonLd={[breadcrumbSchema, serviceSchema]}
       />
 
       <PageHero
         backgroundImage="/images/fitness-cleaning-background.jpg"
-        backgroundPosition="center 38%"
+        backgroundPosition="center"
         overlay="charcoal"
         align="center"
         eyebrow="Fitness cleaning"
         eyebrowIcon={Dumbbell}
-        title="Keep members coming back to a spotless gym."
-        description="Professional cleaning that eliminates odours, sanitises equipment and keeps every studio presentation ready."
+        title="Keep members motivated with spotless, sweat-free spaces."
+        description="Specialist gym cleaners who protect your brand reputation, support compliance and keep every touchpoint fresh."
         actions={
           <>
             <Link to="/contact" className="btn-primary">
-              Get a quote
+              Book a club walkthrough
             </Link>
             <a href="tel:+61411820650" className="btn-secondary">
               Call 0411 820 650
@@ -264,39 +265,13 @@ const FitnessCleaning: React.FC = () => {
 
       <HeroHighlightBand items={heroHighlights} />
 
-      <section className="section-shell" id="member-journey">
-        <div className="container-max mx-auto">
-          <div className="section-heading">
-            <span className="section-heading__eyebrow">Member experience lens</span>
-            <h2 className="section-heading__title">We clean in rhythm with your daily traffic peaks</h2>
-            <p className="section-heading__description">
-              Timetables, casual entries and PT sessions all influence how we stage our crews so members notice constant freshness.
-            </p>
-          </div>
-          <ol className="flex flex-col gap-6 md:flex-row md:gap-8">
-            {memberJourney.map((phase, index) => (
-              <li
-                key={phase.title}
-                className="flex-1 rounded-[32px] border border-white/40 bg-white p-6 shadow-sm"
-              >
-                <span className="text-sm font-semibold uppercase tracking-wide text-celestial-blue-1/70">
-                  Step {index + 1}
-                </span>
-                <h3 className="mt-3 text-2xl font-semibold text-charcoal">{phase.title}</h3>
-                <p className="mt-3 text-jet/80 leading-relaxed">{phase.description}</p>
-              </li>
-            ))}
-          </ol>
-        </div>
-      </section>
-
       <section className="section-shell" id="pain-points">
         <div className="container-max mx-auto">
           <div className="section-heading">
-            <span className="section-heading__eyebrow">What’s not working now?</span>
-            <h2 className="section-heading__title">The gym cleaning frustrations we solve</h2>
+            <span className="section-heading__eyebrow">When gyms call us</span>
+            <h2 className="section-heading__title">Member complaints usually start with the basics</h2>
             <p className="section-heading__description">
-              When hygiene slips, member reviews and retention suffer. We remove the friction so your team can focus on experience and growth.
+              Owners reach out when equipment feels oily, changerooms smell stale or inspectors ask for documentation. We eliminate those distractions.
             </p>
           </div>
           <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
@@ -313,65 +288,44 @@ const FitnessCleaning: React.FC = () => {
         </div>
       </section>
 
-      <section className="section-shell" id="solution">
-        <div className="container-max mx-auto grid gap-12 lg:grid-cols-2 lg:items-center">
-          <div className="glass-panel" data-variant="frost">
-            <img
-              src="/images/fitness-cleaning-background.jpg"
-              alt="Cleaner wiping down gym equipment"
-              className="h-full w-full rounded-[32px] object-cover"
-              loading="lazy"
-              decoding="async"
-            />
-          </div>
+      <section className="section-shell" id="plan">
+        <div className="container-max mx-auto grid gap-12 lg:grid-cols-[1.15fr_1fr] lg:items-center">
           <div className="space-y-6">
             <div className="section-heading" data-align="left">
-              <span className="section-heading__eyebrow">Our approach</span>
-              <h2 className="section-heading__title">High-touch hygiene for high-traffic fitness centres</h2>
+              <span className="section-heading__eyebrow">Your plan</span>
+              <h2 className="section-heading__title">30 days to a gym that smells as good as it looks</h2>
               <p className="section-heading__description">
-                Dedicated crews handle your studios, changerooms and front desk with precision and speed so members notice the difference immediately.
+                We complete a hygiene audit, map your timetable and deploy gym-trained cleaners who know how to care for your equipment. Daily updates keep you in the loop.
               </p>
             </div>
             <ul className="space-y-4 text-jet/80">
               <li className="flex items-start gap-3">
-                <CheckCircle className="h-5 w-5 text-celestial-blue-1" />
-                <span>Colour-coded systems prevent cross-contamination between equipment zones.</span>
+                <CheckCircle className="mt-1 h-5 w-5 text-celestial-blue-1" />
+                <span>Kick-off audit and chemical selection tailored to your franchise or brand standards.</span>
               </li>
               <li className="flex items-start gap-3">
-                <CheckCircle className="h-5 w-5 text-celestial-blue-1" />
-                <span>Odour control treatments keep changerooms and studios smelling clean, not perfumed.</span>
+                <Users className="mt-1 h-5 w-5 text-celestial-blue-1" />
+                <span>Dedicated crews assigned to cardio, strength and studio zones for faster turnarounds.</span>
               </li>
               <li className="flex items-start gap-3">
-                <CheckCircle className="h-5 w-5 text-celestial-blue-1" />
-                <span>Reporting dashboards document every clean for franchise and council checks.</span>
+                <Timer className="mt-1 h-5 w-5 text-celestial-blue-1" />
+                <span>Shift schedules that mirror peak classes, competitions and 24/7 access windows.</span>
               </li>
             </ul>
             <div className="flex flex-wrap gap-4">
               <Link to="/contact" className="btn-primary">
-                Book a hygiene assessment
+                Plan my hygiene audit
               </Link>
               <a href="tel:+61411820650" className="btn-secondary">
-                Call 0411 820 650
+                Talk to a fitness specialist
               </a>
             </div>
           </div>
-        </div>
-      </section>
-
-      <section className="section-shell section-shell--muted" id="programs">
-        <div className="container-max mx-auto">
-          <div className="section-heading">
-            <span className="section-heading__eyebrow">Spaces we transform</span>
-            <h2 className="section-heading__title">Tailored programs for every area of your club</h2>
-            <p className="section-heading__description">
-              From reformer studios to pool decks, each zone receives a dedicated checklist, chemical plan and inspection cycle.
-            </p>
-          </div>
-          <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
-            {studioPrograms.map((program) => (
-              <div key={program.name} className="rounded-[32px] bg-white p-8 shadow-sm">
-                <h3 className="text-2xl font-semibold text-charcoal">{program.name}</h3>
-                <p className="mt-3 text-jet/80 leading-relaxed">{program.detail}</p>
+          <div className="grid gap-4 sm:grid-cols-3">
+            {memberJourney.map((stage) => (
+              <div key={stage.title} className="rounded-[32px] border border-white/40 bg-white p-6 text-center shadow-sm">
+                <h3 className="text-lg font-semibold text-charcoal">{stage.title}</h3>
+                <p className="mt-2 text-sm leading-relaxed text-jet/80">{stage.description}</p>
               </div>
             ))}
           </div>
@@ -380,30 +334,63 @@ const FitnessCleaning: React.FC = () => {
 
       <HowItWorks
         eyebrow="How onboarding works"
-        title="Four steps to launch your gym cleaning program"
-        description="A structured process keeps your team in the loop from quote to first workout-ready clean."
+        title="Four steps from first call to fan-favourite feedback"
+        description="From hygiene audit to live reporting, every step keeps your members confident and your brand compliant."
       />
 
+      <section className="section-shell section-shell--muted" id="studio-programs">
+        <div className="container-max mx-auto">
+          <div className="section-heading">
+            <span className="section-heading__eyebrow">Zone coverage</span>
+            <h2 className="section-heading__title">Programs tuned to each area of your club</h2>
+            <p className="section-heading__description">
+              Strength floors, reformer studios and recovery zones each receive a tailored scope with equipment-safe products.
+            </p>
+          </div>
+          <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+            {studioPrograms.map((program) => (
+              <div key={program.name} className="rounded-[32px] bg-white p-8 shadow-sm">
+                <h3 className="text-2xl font-semibold text-charcoal">{program.name}</h3>
+                <p className="mt-3 leading-relaxed text-jet/80">{program.detail}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="section-shell" id="testimonials">
+        <div className="container-max mx-auto">
+          <div className="section-heading">
+            <span className="section-heading__eyebrow">Social proof</span>
+            <h2 className="section-heading__title">Fitness brands that count on MOG Cleaning</h2>
+            <p className="section-heading__description">
+              Hear from gym owners and franchise leaders who’ve lifted member satisfaction by keeping hygiene front of mind.
+            </p>
+          </div>
+          <TestimonialCarousel testimonials={testimonials} className="mx-auto max-w-4xl" />
+        </div>
+      </section>
+
       <QuoteSection
-        eyebrow="Start today"
-        title="Request your gym cleaning quote"
-        description="Tell us about your equipment mix, membership volume and cleaning schedule. We’ll return a tailored proposal within 24 hours."
+        eyebrow="Start your program"
+        title="Request your fitness centre cleaning proposal"
+        description="Tell us about your membership size, class timetable and hygiene challenges. We’ll send a tailored scope, onboarding plan and pricing within 24 hours."
         bullets={[
-          'Flexible scheduling around peak times',
-          'Certified disinfectants for shared equipment',
-          'Real-time communication with supervisors',
+          'Gym-trained crews with police checks',
+          'Odour control and moisture management plans',
+          'Compliance-ready reporting and photo logs',
         ]}
-        formTitle="Tell us about your fitness space"
-        formSubtitle="We’ll be in touch within one business day."
+        formTitle="Tell us about your club"
+        formSubtitle="Your dedicated fitness contact will respond within one business day."
       />
 
       <section className="section-shell" id="benefits">
         <div className="container-max mx-auto">
           <div className="section-heading">
-            <span className="section-heading__eyebrow">Benefits</span>
-            <h2 className="section-heading__title">Why Brisbane gyms choose MOG Cleaning</h2>
+            <span className="section-heading__eyebrow">Why clubs stay</span>
+            <h2 className="section-heading__title">Outcomes for your members, staff and brand</h2>
             <p className="section-heading__description">
-              Confidence in hygiene keeps members loyal and reviews positive. Our crews protect your reputation daily.
+              Consistent presentation, healthier air quality and easy compliance keep retention high and complaints low.
             </p>
           </div>
           <div className="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-4">
@@ -413,7 +400,7 @@ const FitnessCleaning: React.FC = () => {
                   <benefit.icon className="h-7 w-7" />
                 </div>
                 <h3 className="text-xl font-semibold text-charcoal">{benefit.title}</h3>
-                <p className="text-jet/80 leading-relaxed">{benefit.description}</p>
+                <p className="leading-relaxed text-jet/80">{benefit.description}</p>
               </div>
             ))}
           </div>
@@ -424,31 +411,18 @@ const FitnessCleaning: React.FC = () => {
         <div className="container-max mx-auto">
           <div className="section-heading">
             <span className="section-heading__eyebrow">What’s included</span>
-            <h2 className="section-heading__title">Gym & studio cleaning checklist</h2>
+            <h2 className="section-heading__title">Fitness cleaning checklist</h2>
             <p className="section-heading__description">
-              A detailed program covering equipment, changerooms and member touchpoints keeps every visit predictable.
+              Every visit follows a documented scope so equipment, changerooms and studios stay immaculate.
             </p>
           </div>
           <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
             {inclusions.map((inclusion) => (
               <div key={inclusion} className="service-item p-6">
-                <p className="text-charcoal font-medium">{inclusion}</p>
+                <p className="font-medium text-charcoal">{inclusion}</p>
               </div>
             ))}
           </div>
-        </div>
-      </section>
-
-      <section className="section-shell" id="testimonials">
-        <div className="container-max mx-auto">
-          <div className="section-heading">
-            <span className="section-heading__eyebrow">Results</span>
-            <h2 className="section-heading__title">What Brisbane fitness leaders say</h2>
-            <p className="section-heading__description">
-              Hear from gym owners and franchise teams who rely on MOG Cleaning to protect their brand standards.
-            </p>
-          </div>
-          <TestimonialCarousel testimonials={testimonials} className="mx-auto max-w-4xl" />
         </div>
       </section>
 
@@ -458,20 +432,20 @@ const FitnessCleaning: React.FC = () => {
             <span className="section-heading__eyebrow">FAQs</span>
             <h2 className="section-heading__title">Fitness cleaning FAQs</h2>
             <p className="section-heading__description">
-              Learn how we coordinate after-hours cleans, equipment sanitising and membership area resets for your venue.
+              Get answers on scheduling, odour control and compliance before you confirm your contract.
             </p>
           </div>
-          <FAQAccordion faqs={faqs} className="max-w-4xl mx-auto" />
+          <FAQAccordion faqs={faqs} className="mx-auto max-w-4xl" />
         </div>
       </section>
 
       <section className="section-shell section-shell--muted" id="related">
         <div className="container-max mx-auto">
           <div className="section-heading">
-            <span className="section-heading__eyebrow">Explore more programs</span>
-            <h2 className="section-heading__title">Support for every part of your business</h2>
+            <span className="section-heading__eyebrow">Need something else?</span>
+            <h2 className="section-heading__title">Explore other services</h2>
             <p className="section-heading__description">
-              Keep brand consistency across offices, hospitality venues and customer spaces with MOG Cleaning.
+              Offices, hospitality venues and retail stores enjoy the same responsive communication and spotless finish.
             </p>
           </div>
           <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
@@ -494,9 +468,9 @@ const FitnessCleaning: React.FC = () => {
             <span className="pill-chip bg-white/10 text-white">
               <Sparkles className="h-4 w-4" /> Trusted by Brisbane gyms
             </span>
-            <h2 className="section-heading__title text-white">Ready to lift your hygiene standards?</h2>
+            <h2 className="section-heading__title text-white">Ready to wow members at every visit?</h2>
             <p className="section-heading__description text-white/80">
-              Schedule a walkthrough to receive a tailored plan, pricing and onboarding timeline within 24 hours.
+              Book a walkthrough and receive a tailored scope, pricing and onboarding plan within 24 hours.
             </p>
             <div className="flex flex-col items-center justify-center gap-4 sm:flex-row sm:gap-6">
               <Link to="/contact" className="btn-primary">
@@ -509,6 +483,15 @@ const FitnessCleaning: React.FC = () => {
           </div>
         </div>
       </section>
+
+      <StickyCTABar
+        title="Keep members raving about cleanliness"
+        description="Schedule a walkthrough to launch your tailored fitness cleaning program."
+        primaryLabel="Book my walkthrough"
+        primaryHref="/contact"
+        secondaryLabel="Call 0411 820 650"
+        secondaryHref="tel:+61411820650"
+      />
     </div>
   );
 };

--- a/src/pages/services/HealthCleaning.tsx
+++ b/src/pages/services/HealthCleaning.tsx
@@ -20,6 +20,7 @@ import PageHero from '../../components/PageHero';
 import QuoteSection from '../../components/QuoteSection';
 import HeroHighlightBand from '../../components/HeroHighlightBand';
 import HowItWorks from '../../components/HowItWorks';
+import StickyCTABar from '../../components/StickyCTABar';
 
 const HealthCleaning: React.FC = () => {
   const inclusions = [
@@ -231,30 +232,30 @@ const HealthCleaning: React.FC = () => {
   };
 
   return (
-    <div>
+    <div className="pb-32">
       <SEO
         title={pageTitle}
         description={pageDescription}
         type="service"
-        image="/images/medical-cleaning-background.jpg"
-        imageAlt="Medical treatment room being cleaned"
-        keywords={['medical cleaning Brisbane', 'clinic cleaners brisbane', 'healthcare cleaning services']}
+        image="/images/healthcare-cleaning-background.jpg"
+        imageAlt="Clean Brisbane medical clinic"
+        keywords={['healthcare cleaning Brisbane', 'medical centre cleaners', 'infection control cleaning']}
         jsonLd={[breadcrumbSchema, serviceSchema]}
       />
 
       <PageHero
-        backgroundImage="/images/medical-cleaning-background.jpg"
-        backgroundPosition="center 45%"
+        backgroundImage="/images/healthcare-cleaning-background.jpg"
+        backgroundPosition="center"
         overlay="charcoal"
         align="center"
         eyebrow="Healthcare cleaning"
         eyebrowIcon={Heart}
-        title="Clinically clean spaces that protect patients and practitioners."
-        description="Specialist crews maintain infection control, presentation and documentation for every appointment."
+        title="Keep every clinic space patient-ready and audit confident."
+        description="Infection-control trained crews who align with your compliance requirements and deliver spotless clinical environments."
         actions={
           <>
             <Link to="/contact" className="btn-primary">
-              Get a quote
+              Book a compliance consult
             </Link>
             <a href="tel:+61411820650" className="btn-secondary">
               Call 0411 820 650
@@ -265,45 +266,13 @@ const HealthCleaning: React.FC = () => {
 
       <HeroHighlightBand items={heroHighlights} />
 
-      <section className="section-shell section-shell--muted" id="compliance">
-        <div className="container-max mx-auto grid gap-8 lg:grid-cols-[1.15fr_1fr] lg:items-center">
-          <div className="space-y-6">
-            <div className="section-heading" data-align="left">
-              <span className="section-heading__eyebrow">Clinical governance</span>
-              <h2 className="section-heading__title">Proof you can hand straight to auditors</h2>
-              <p className="section-heading__description">
-                Every healthcare partnership begins with a compliance pack covering inductions, SWMS, insurances and infection control procedures specific to your modalities.
-              </p>
-            </div>
-            <ul className="space-y-4 text-jet/80">
-              <li className="flex items-start gap-3">
-                <ShieldCheck className="mt-1 h-5 w-5 text-celestial-blue-1" />
-                <span>Site-specific zoning maps covering public, clinical and sterile areas.</span>
-              </li>
-              <li className="flex items-start gap-3">
-                <ClipboardList className="mt-1 h-5 w-5 text-celestial-blue-1" />
-                <span>Daily, weekly and monthly checklists with sign-off visibility for practice managers.</span>
-              </li>
-            </ul>
-          </div>
-          <div className="grid gap-4">
-            {complianceFrameworks.map((item) => (
-              <div key={item.label} className="glass-panel space-y-2 rounded-3xl p-6" data-variant="frost">
-                <p className="text-sm font-semibold uppercase tracking-wide text-celestial-blue-1/70">{item.label}</p>
-                <p className="text-charcoal text-lg font-semibold">{item.description}</p>
-              </div>
-            ))}
-          </div>
-        </div>
-      </section>
-
       <section className="section-shell" id="pain-points">
         <div className="container-max mx-auto">
           <div className="section-heading">
-            <span className="section-heading__eyebrow">Risks to your practice</span>
-            <h2 className="section-heading__title">Why clinics move to MOG Cleaning</h2>
+            <span className="section-heading__eyebrow">When clinics reach out</span>
+            <h2 className="section-heading__title">You can’t risk missed touchpoints or paperwork gaps</h2>
             <p className="section-heading__description">
-              Healthcare environments demand precision. We address the compliance and experience gaps that keep practice managers awake at night.
+              Practice managers come to us when the basics aren’t being met—smudged reception counters, no zoning, or missing SWMS before accreditation.
             </p>
           </div>
           <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
@@ -320,70 +289,44 @@ const HealthCleaning: React.FC = () => {
         </div>
       </section>
 
-      <section className="section-shell" id="solution">
-        <div className="container-max mx-auto grid gap-12 lg:grid-cols-2 lg:items-center">
-          <div className="glass-panel" data-variant="frost">
-            <img
-              src="/images/medical-cleaning-background.jpg"
-              alt="Healthcare cleaner preparing a treatment room"
-              className="h-full w-full rounded-[32px] object-cover"
-              loading="lazy"
-              decoding="async"
-            />
-          </div>
+      <section className="section-shell" id="plan">
+        <div className="container-max mx-auto grid gap-12 lg:grid-cols-[1.15fr_1fr] lg:items-center">
           <div className="space-y-6">
             <div className="section-heading" data-align="left">
-              <span className="section-heading__eyebrow">Our approach</span>
-              <h2 className="section-heading__title">Infection control woven into every routine</h2>
+              <span className="section-heading__eyebrow">Your plan</span>
+              <h2 className="section-heading__title">30 days to confident, compliant cleaning</h2>
               <p className="section-heading__description">
-                From zoning maps to sealed chemical caddies, our cleaners follow strict procedures that protect staff and patients in every room.
+                We audit your current program, map zoning, then deploy credentialled cleaners with full documentation packs. Supervisors provide daily updates so you’re always audit ready.
               </p>
             </div>
             <ul className="space-y-4 text-jet/80">
               <li className="flex items-start gap-3">
-                <CheckCircle className="h-5 w-5 text-celestial-blue-1" />
-                <span>Colour-coded cloths and mop systems for admin, public and clinical zones.</span>
+                <CheckCircle className="mt-1 h-5 w-5 text-celestial-blue-1" />
+                <span>Clinical walkthrough and risk assessment completed in week one.</span>
               </li>
               <li className="flex items-start gap-3">
-                <CheckCircle className="h-5 w-5 text-celestial-blue-1" />
-                <span>TGA-approved disinfectants validated against bacteria and viruses common in healthcare.</span>
+                <ShieldCheck className="mt-1 h-5 w-5 text-celestial-blue-1" />
+                <span>Zoned protocols created for treatment, admin and public areas with colour-coded systems.</span>
               </li>
               <li className="flex items-start gap-3">
-                <CheckCircle className="h-5 w-5 text-celestial-blue-1" />
-                <span>Documented spill response and sharps incident procedures for full compliance.</span>
+                <Clock className="mt-1 h-5 w-5 text-celestial-blue-1" />
+                <span>Rapid response crews available for urgent turnovers, outbreaks and spill management.</span>
               </li>
             </ul>
             <div className="flex flex-wrap gap-4">
               <Link to="/contact" className="btn-primary">
-                Book a compliance walkthrough
+                Schedule my consult
               </Link>
               <a href="tel:+61411820650" className="btn-secondary">
-                Call 0411 820 650
+                Speak to clinical support
               </a>
             </div>
           </div>
-        </div>
-      </section>
-
-      <section className="section-shell" id="clinical-spaces">
-        <div className="container-max mx-auto grid gap-10 lg:grid-cols-[1fr_1.1fr] lg:items-center">
-          <div className="space-y-6">
-            <div className="section-heading" data-align="left">
-              <span className="section-heading__eyebrow">Clinical coverage</span>
-              <h2 className="section-heading__title">Programs tailored to your modality mix</h2>
-              <p className="section-heading__description">
-                Each facility receives a bespoke scope of works that aligns with practitioner schedules, treatment types and accreditation needs.
-              </p>
-            </div>
-            <Link to="/contact" className="btn-secondary w-full max-w-xs">
-              Schedule a site discovery
-            </Link>
-          </div>
-          <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
-            {clinicalSpaces.map((space) => (
-              <div key={space.name} className="rounded-[32px] border border-white/40 bg-white p-8 shadow-sm">
-                <h3 className="text-2xl font-semibold text-charcoal">{space.name}</h3>
-                <p className="mt-3 text-jet/80 leading-relaxed">{space.detail}</p>
+          <div className="grid gap-4 sm:grid-cols-3">
+            {complianceFrameworks.map((framework) => (
+              <div key={framework.label} className="rounded-[32px] border border-white/40 bg-white p-6 text-center shadow-sm">
+                <h3 className="text-lg font-semibold text-charcoal">{framework.label}</h3>
+                <p className="mt-2 text-sm leading-relaxed text-jet/80">{framework.description}</p>
               </div>
             ))}
           </div>
@@ -391,31 +334,64 @@ const HealthCleaning: React.FC = () => {
       </section>
 
       <HowItWorks
-        eyebrow="Implementation"
-        title="Four steps to a compliant healthcare cleaning program"
-        description="A predictable onboarding keeps your infection control officer confident from the first visit."
+        eyebrow="How onboarding works"
+        title="Four steps from first call to audit-ready cleaning"
+        description="Every healthcare client follows the same proven process so you stay in control of infection protocols and reporting."
       />
 
+      <section className="section-shell section-shell--muted" id="spaces">
+        <div className="container-max mx-auto">
+          <div className="section-heading">
+            <span className="section-heading__eyebrow">Clinical spaces</span>
+            <h2 className="section-heading__title">Detailed support for every wing</h2>
+            <p className="section-heading__description">
+              No two healthcare facilities are the same. We tailor checklists for every clinical space you manage.
+            </p>
+          </div>
+          <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+            {clinicalSpaces.map((space) => (
+              <div key={space.name} className="rounded-[32px] bg-white p-8 shadow-sm">
+                <h3 className="text-2xl font-semibold text-charcoal">{space.name}</h3>
+                <p className="mt-3 leading-relaxed text-jet/80">{space.detail}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="section-shell" id="testimonials">
+        <div className="container-max mx-auto">
+          <div className="section-heading">
+            <span className="section-heading__eyebrow">Proof that matters</span>
+            <h2 className="section-heading__title">Healthcare teams that trust MOG Cleaning</h2>
+            <p className="section-heading__description">
+              Hear from medical centres that rely on us for compliant cleaning and patient-ready spaces.
+            </p>
+          </div>
+          <TestimonialCarousel testimonials={testimonials} className="mx-auto max-w-4xl" />
+        </div>
+      </section>
+
       <QuoteSection
-        eyebrow="Start now"
+        eyebrow="Start your program"
         title="Request your healthcare cleaning proposal"
-        description="Share your practice type, consultation room count and compliance requirements. We’ll send a tailored scope and onboarding plan within 24 hours."
+        description="Tell us about your clinical areas, zoning requirements and key compliance needs. We’ll craft a program, onboarding plan and pricing within 24 hours."
         bullets={[
           'Infection-control trained cleaners',
-          'Detailed zoning maps and checklists',
-          'Audit-ready documentation supplied',
+          'Zoned protocols and PPE ready',
+          'Documentation supplied for audits',
         ]}
-        formTitle="Tell us about your clinic"
-        formSubtitle="A healthcare onboarding specialist will respond within one business day."
+        formTitle="Tell us about your facility"
+        formSubtitle="Your dedicated healthcare contact will respond within one business day."
       />
 
       <section className="section-shell" id="benefits">
         <div className="container-max mx-auto">
           <div className="section-heading">
-            <span className="section-heading__eyebrow">Benefits</span>
-            <h2 className="section-heading__title">What you gain with MOG Cleaning</h2>
+            <span className="section-heading__eyebrow">Why healthcare leaders choose us</span>
+            <h2 className="section-heading__title">Outcomes for your teams and patients</h2>
             <p className="section-heading__description">
-              Precision cleaning protects patient trust, staff wellbeing and accreditation results.
+              Precision cleaning, infection control protocols and detailed reporting keep your practice running smoothly.
             </p>
           </div>
           <div className="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-4">
@@ -425,7 +401,7 @@ const HealthCleaning: React.FC = () => {
                   <benefit.icon className="h-7 w-7" />
                 </div>
                 <h3 className="text-xl font-semibold text-charcoal">{benefit.title}</h3>
-                <p className="text-jet/80 leading-relaxed">{benefit.description}</p>
+                <p className="leading-relaxed text-jet/80">{benefit.description}</p>
               </div>
             ))}
           </div>
@@ -438,29 +414,16 @@ const HealthCleaning: React.FC = () => {
             <span className="section-heading__eyebrow">What’s included</span>
             <h2 className="section-heading__title">Healthcare cleaning checklist</h2>
             <p className="section-heading__description">
-              Each visit follows a documented sequence covering clinical and public areas to maintain compliance.
+              Every visit follows strict infection control procedures and documentation so nothing is missed.
             </p>
           </div>
           <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
             {inclusions.map((inclusion) => (
               <div key={inclusion} className="service-item p-6">
-                <p className="text-charcoal font-medium">{inclusion}</p>
+                <p className="font-medium text-charcoal">{inclusion}</p>
               </div>
             ))}
           </div>
-        </div>
-      </section>
-
-      <section className="section-shell" id="testimonials">
-        <div className="container-max mx-auto">
-          <div className="section-heading">
-            <span className="section-heading__eyebrow">Results</span>
-            <h2 className="section-heading__title">Feedback from healthcare leaders</h2>
-            <p className="section-heading__description">
-              Hear from practices that trust MOG Cleaning to support patient safety and accreditation outcomes.
-            </p>
-          </div>
-          <TestimonialCarousel testimonials={testimonials} className="mx-auto max-w-4xl" />
         </div>
       </section>
 
@@ -470,20 +433,20 @@ const HealthCleaning: React.FC = () => {
             <span className="section-heading__eyebrow">FAQs</span>
             <h2 className="section-heading__title">Healthcare cleaning FAQs</h2>
             <p className="section-heading__description">
-              Understand our infection control processes, compliance documentation and response times before you engage us.
+              Learn how we handle infection control, patient schedules and compliance documentation.
             </p>
           </div>
-          <FAQAccordion faqs={faqs} className="max-w-4xl mx-auto" />
+          <FAQAccordion faqs={faqs} className="mx-auto max-w-4xl" />
         </div>
       </section>
 
       <section className="section-shell section-shell--muted" id="related">
         <div className="container-max mx-auto">
           <div className="section-heading">
-            <span className="section-heading__eyebrow">Explore more support</span>
-            <h2 className="section-heading__title">Consistent standards across every site</h2>
+            <span className="section-heading__eyebrow">Need something else?</span>
+            <h2 className="section-heading__title">Explore other services</h2>
             <p className="section-heading__description">
-              Extend the same level of care to your offices, classrooms or specialist facilities.
+              From office buildings to schools, we deliver the same detail-focused approach across Brisbane.
             </p>
           </div>
           <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
@@ -504,11 +467,11 @@ const HealthCleaning: React.FC = () => {
         <div className="container-max mx-auto text-center">
           <div className="mx-auto max-w-3xl space-y-6">
             <span className="pill-chip bg-white/10 text-white">
-              <Sparkles className="h-4 w-4" /> Trusted by Brisbane clinics
+              <Sparkles className="h-4 w-4" /> Trusted by healthcare practices
             </span>
-            <h2 className="section-heading__title text-white">Ready for inspection-ready healthcare spaces?</h2>
+            <h2 className="section-heading__title text-white">Ready for a compliant, patient-ready clinic?</h2>
             <p className="section-heading__description text-white/80">
-              Book a walkthrough and receive a compliance-led cleaning proposal within 24 hours.
+              Book a walkthrough and receive a tailored scope, pricing and onboarding plan within 24 hours.
             </p>
             <div className="flex flex-col items-center justify-center gap-4 sm:flex-row sm:gap-6">
               <Link to="/contact" className="btn-primary">
@@ -521,6 +484,15 @@ const HealthCleaning: React.FC = () => {
           </div>
         </div>
       </section>
+
+      <StickyCTABar
+        title="Protect every patient experience"
+        description="Book a compliance consult and secure an audit-ready cleaning program."
+        primaryLabel="Book my consult"
+        primaryHref="/contact"
+        secondaryLabel="Call 0411 820 650"
+        secondaryHref="tel:+61411820650"
+      />
     </div>
   );
 };

--- a/src/pages/services/HospitalityCleaning.tsx
+++ b/src/pages/services/HospitalityCleaning.tsx
@@ -20,6 +20,7 @@ import PageHero from '../../components/PageHero';
 import QuoteSection from '../../components/QuoteSection';
 import HeroHighlightBand from '../../components/HeroHighlightBand';
 import HowItWorks from '../../components/HowItWorks';
+import StickyCTABar from '../../components/StickyCTABar';
 
 const HospitalityCleaning: React.FC = () => {
   const inclusions = [
@@ -231,30 +232,30 @@ const HospitalityCleaning: React.FC = () => {
   };
 
   return (
-    <div>
+    <div className="pb-32">
       <SEO
         title={pageTitle}
         description={pageDescription}
         type="service"
-        image="/images/hotel-cleaning-background.jpg"
-        imageAlt="Cleaner preparing a hotel dining area"
-        keywords={['hospitality cleaning Brisbane', 'restaurant cleaners', 'hotel cleaning services']}
+        image="/images/hospitality-cleaning-background.jpg"
+        imageAlt="Luxury hospitality venue being cleaned"
+        keywords={['hospitality cleaning Brisbane', 'hotel cleaners Brisbane', 'restaurant cleaning services']}
         jsonLd={[breadcrumbSchema, serviceSchema]}
       />
 
       <PageHero
-        backgroundImage="/images/hotel-cleaning-background.jpg"
-        backgroundPosition="center 40%"
+        backgroundImage="/images/hospitality-cleaning-background.jpg"
+        backgroundPosition="center"
         overlay="charcoal"
         align="center"
         eyebrow="Hospitality cleaning"
         eyebrowIcon={Hotel}
-        title="Hospitality spaces that wow every guest, every time."
-        description="From the lobby to the kitchen pass, your venue stays immaculate with crews who understand your brand."
+        title="Deliver five-star moments from lobby to last seating."
+        description="Detail-focused crews who protect your guest experience, support your chefs and reset venues fast between events."
         actions={
           <>
             <Link to="/contact" className="btn-primary">
-              Get a quote
+              Book a venue walkthrough
             </Link>
             <a href="tel:+61411820650" className="btn-secondary">
               Call 0411 820 650
@@ -265,37 +266,13 @@ const HospitalityCleaning: React.FC = () => {
 
       <HeroHighlightBand items={heroHighlights} />
 
-      <section className="section-shell" id="service-windows">
-        <div className="container-max mx-auto overflow-hidden rounded-[40px] bg-gradient-to-r from-charcoal to-jet p-8 text-white md:p-12">
-          <div className="flex flex-col gap-10 lg:flex-row lg:items-center lg:justify-between">
-            <div className="max-w-xl space-y-4">
-              <span className="pill-chip bg-white/10 text-white">Service windows</span>
-              <h2 className="text-3xl font-semibold leading-tight md:text-4xl">
-                Crews operate when your guests and chefs need us most
-              </h2>
-              <p className="text-white/80">
-                From first seating to last call, our scheduling team builds rosters that protect ambience, food safety and review scores.
-              </p>
-            </div>
-            <div className="grid flex-1 gap-4 md:grid-cols-3">
-              {serviceWindows.map((window) => (
-                <div key={window.name} className="rounded-3xl bg-white/10 p-6 backdrop-blur">
-                  <h3 className="text-lg font-semibold">{window.name}</h3>
-                  <p className="mt-2 text-sm text-white/80">{window.detail}</p>
-                </div>
-              ))}
-            </div>
-          </div>
-        </div>
-      </section>
-
       <section className="section-shell" id="pain-points">
         <div className="container-max mx-auto">
           <div className="section-heading">
-            <span className="section-heading__eyebrow">What’s hurting your reviews?</span>
-            <h2 className="section-heading__title">Hospitality cleaning frustrations we fix</h2>
+            <span className="section-heading__eyebrow">When operators call us</span>
+            <h2 className="section-heading__title">Guest reviews drop when presentation slips</h2>
             <p className="section-heading__description">
-              Venue managers turn to MOG Cleaning when presentation, compliance and turnaround times are letting guests down.
+              Hospitality leaders reach out when fingerprints, grease or slow turnovers start impacting revenue. We restore polish and pace.
             </p>
           </div>
           <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
@@ -312,65 +289,44 @@ const HospitalityCleaning: React.FC = () => {
         </div>
       </section>
 
-      <section className="section-shell" id="solution">
-        <div className="container-max mx-auto grid gap-12 lg:grid-cols-2 lg:items-center">
-          <div className="glass-panel" data-variant="frost">
-            <img
-              src="/images/hotel-cleaning-background.jpg"
-              alt="Cleaner preparing a hospitality venue"
-              className="h-full w-full rounded-[32px] object-cover"
-              loading="lazy"
-              decoding="async"
-            />
-          </div>
+      <section className="section-shell" id="plan">
+        <div className="container-max mx-auto grid gap-12 lg:grid-cols-[1.15fr_1fr] lg:items-center">
           <div className="space-y-6">
             <div className="section-heading" data-align="left">
-              <span className="section-heading__eyebrow">Our approach</span>
-              <h2 className="section-heading__title">Presentation, compliance and speed in one program</h2>
+              <span className="section-heading__eyebrow">Your plan</span>
+              <h2 className="section-heading__title">30 days to reviews that rave about cleanliness</h2>
               <p className="section-heading__description">
-                We partner with your operations team to keep guest areas immaculate, kitchens audit-ready and events running smoothly.
+                We map your service windows, document HACCP requirements and onboard hospitality-trained teams. Nightly reporting keeps managers informed without chasing updates.
               </p>
             </div>
             <ul className="space-y-4 text-jet/80">
               <li className="flex items-start gap-3">
-                <CheckCircle className="h-5 w-5 text-celestial-blue-1" />
-                <span>Dedicated crews for front-of-house, kitchen and event spaces.</span>
+                <CheckCircle className="mt-1 h-5 w-5 text-celestial-blue-1" />
+                <span>Kick-off walkthrough capturing front and back-of-house priorities plus compliance needs.</span>
               </li>
               <li className="flex items-start gap-3">
-                <CheckCircle className="h-5 w-5 text-celestial-blue-1" />
-                <span>HACCP-aligned checklists and reporting for food safety compliance.</span>
+                <Users className="mt-1 h-5 w-5 text-celestial-blue-1" />
+                <span>Dedicated supervisors coordinate with your duty managers before and after every shift.</span>
               </li>
               <li className="flex items-start gap-3">
-                <CheckCircle className="h-5 w-5 text-celestial-blue-1" />
-                <span>On-call supervisors to respond to spills, VIP visits and late-running events.</span>
+                <Clock className="mt-1 h-5 w-5 text-celestial-blue-1" />
+                <span>Flexible rosters covering late closes, breakfast turnover and rapid event resets.</span>
               </li>
             </ul>
             <div className="flex flex-wrap gap-4">
               <Link to="/contact" className="btn-primary">
-                Book a venue walkthrough
+                Schedule my venue tour
               </Link>
               <a href="tel:+61411820650" className="btn-secondary">
-                Call 0411 820 650
+                Speak with hospitality support
               </a>
             </div>
           </div>
-        </div>
-      </section>
-
-      <section className="section-shell section-shell--muted" id="venue-boards">
-        <div className="container-max mx-auto">
-          <div className="section-heading">
-            <span className="section-heading__eyebrow">Venue playbooks</span>
-            <h2 className="section-heading__title">A tailored approach for every hospitality concept</h2>
-            <p className="section-heading__description">
-              Whether you manage a luxury lobby or a bustling function centre, we build a cleaning storyboard that mirrors the experience you promise guests.
-            </p>
-          </div>
-          <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
-            {venueBoards.map((board) => (
-              <div key={board.title} className="rounded-[32px] border border-white/40 bg-white p-8 shadow-sm">
-                <h3 className="text-2xl font-semibold text-charcoal">{board.title}</h3>
-                <p className="mt-3 text-jet/80 leading-relaxed">{board.body}</p>
+          <div className="grid gap-4 sm:grid-cols-3">
+            {serviceWindows.map((window) => (
+              <div key={window.name} className="rounded-[32px] border border-white/40 bg-white p-6 text-center shadow-sm">
+                <h3 className="text-lg font-semibold text-charcoal">{window.name}</h3>
+                <p className="mt-2 text-sm leading-relaxed text-jet/80">{window.detail}</p>
               </div>
             ))}
           </div>
@@ -379,30 +335,63 @@ const HospitalityCleaning: React.FC = () => {
 
       <HowItWorks
         eyebrow="How onboarding works"
-        title="Four steps to hospitality-ready cleaning"
-        description="A proven process keeps your team informed and your guests delighted from day one."
+        title="Four steps to five-star presentation"
+        description="From compliance audit to live reporting, our process keeps GMs, chefs and event teams aligned from day one."
       />
 
+      <section className="section-shell section-shell--muted" id="venues">
+        <div className="container-max mx-auto">
+          <div className="section-heading">
+            <span className="section-heading__eyebrow">Venue coverage</span>
+            <h2 className="section-heading__title">Programs tuned to every hospitality environment</h2>
+            <p className="section-heading__description">
+              Hotels, fine dining and event centres receive dedicated crews, tailored checklists and reporting that suits their brand standards.
+            </p>
+          </div>
+          <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+            {venueBoards.map((board) => (
+              <div key={board.title} className="rounded-[32px] bg-white p-8 shadow-sm">
+                <h3 className="text-2xl font-semibold text-charcoal">{board.title}</h3>
+                <p className="mt-3 leading-relaxed text-jet/80">{board.body}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="section-shell" id="testimonials">
+        <div className="container-max mx-auto">
+          <div className="section-heading">
+            <span className="section-heading__eyebrow">Proof for owners & chefs</span>
+            <h2 className="section-heading__title">Hospitality brands that trust MOG Cleaning</h2>
+            <p className="section-heading__description">
+              Hear from operators who now enjoy glowing guest feedback, easier inspections and faster event flips.
+            </p>
+          </div>
+          <TestimonialCarousel testimonials={testimonials} className="mx-auto max-w-4xl" />
+        </div>
+      </section>
+
       <QuoteSection
-        eyebrow="Start planning"
+        eyebrow="Start your program"
         title="Request your hospitality cleaning proposal"
-        description="Share your venue type, service schedule and event calendar. We’ll respond with a tailored program within 24 hours."
+        description="Share your service windows, kitchen requirements and event schedule. We’ll send a tailored scope, onboarding plan and pricing within 24 hours."
         bullets={[
-          'Front and back-of-house specialists',
-          'HACCP-aligned documentation',
-          'Rapid event turnaround crews',
+          'HACCP-aligned cleaning documentation',
+          'Front and back-of-house presentation teams',
+          'Rapid response crews for events and VIPs',
         ]}
         formTitle="Tell us about your venue"
-        formSubtitle="A hospitality specialist will confirm next steps within one business day."
+        formSubtitle="Your dedicated hospitality contact will respond within one business day."
       />
 
       <section className="section-shell" id="benefits">
         <div className="container-max mx-auto">
           <div className="section-heading">
-            <span className="section-heading__eyebrow">Benefits</span>
-            <h2 className="section-heading__title">Why hospitality brands choose MOG Cleaning</h2>
+            <span className="section-heading__eyebrow">Why venues stay</span>
+            <h2 className="section-heading__title">Outcomes for your guests, chefs and coordinators</h2>
             <p className="section-heading__description">
-              We help your team deliver memorable experiences by keeping every touchpoint pristine and compliant.
+              Consistent presentation, compliant kitchens and rapid resets increase guest satisfaction and repeat bookings.
             </p>
           </div>
           <div className="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-4">
@@ -412,7 +401,7 @@ const HospitalityCleaning: React.FC = () => {
                   <benefit.icon className="h-7 w-7" />
                 </div>
                 <h3 className="text-xl font-semibold text-charcoal">{benefit.title}</h3>
-                <p className="text-jet/80 leading-relaxed">{benefit.description}</p>
+                <p className="leading-relaxed text-jet/80">{benefit.description}</p>
               </div>
             ))}
           </div>
@@ -425,29 +414,16 @@ const HospitalityCleaning: React.FC = () => {
             <span className="section-heading__eyebrow">What’s included</span>
             <h2 className="section-heading__title">Hospitality cleaning checklist</h2>
             <p className="section-heading__description">
-              Every visit follows detailed checklists for guest areas, kitchens and event spaces, so nothing is missed.
+              Every visit follows a documented scope so front-of-house sparkle and kitchen hygiene never slip.
             </p>
           </div>
           <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
             {inclusions.map((inclusion) => (
               <div key={inclusion} className="service-item p-6">
-                <p className="text-charcoal font-medium">{inclusion}</p>
+                <p className="font-medium text-charcoal">{inclusion}</p>
               </div>
             ))}
           </div>
-        </div>
-      </section>
-
-      <section className="section-shell" id="testimonials">
-        <div className="container-max mx-auto">
-          <div className="section-heading">
-            <span className="section-heading__eyebrow">Results</span>
-            <h2 className="section-heading__title">What Brisbane venues say</h2>
-            <p className="section-heading__description">
-              Hear from hotels, restaurants and event centres that rely on MOG Cleaning to keep guests impressed.
-            </p>
-          </div>
-          <TestimonialCarousel testimonials={testimonials} className="mx-auto max-w-4xl" />
         </div>
       </section>
 
@@ -457,20 +433,20 @@ const HospitalityCleaning: React.FC = () => {
             <span className="section-heading__eyebrow">FAQs</span>
             <h2 className="section-heading__title">Hospitality cleaning FAQs</h2>
             <p className="section-heading__description">
-              Discover how we coordinate front-of-house presentation, kitchen hygiene and event support without disrupting guest service.
+              Clarify how we work around service times, manage compliance and support events before you onboard.
             </p>
           </div>
-          <FAQAccordion faqs={faqs} className="max-w-4xl mx-auto" />
+          <FAQAccordion faqs={faqs} className="mx-auto max-w-4xl" />
         </div>
       </section>
 
       <section className="section-shell section-shell--muted" id="related">
         <div className="container-max mx-auto">
           <div className="section-heading">
-            <span className="section-heading__eyebrow">Explore more programs</span>
-            <h2 className="section-heading__title">Consistent experiences across your portfolio</h2>
+            <span className="section-heading__eyebrow">Need something else?</span>
+            <h2 className="section-heading__title">Explore other services</h2>
             <p className="section-heading__description">
-              Extend MOG Cleaning to your retail spaces, offices or back-of-house areas for a unified standard.
+              From offices to retail, our teams deliver the same polished experience across Brisbane.
             </p>
           </div>
           <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
@@ -493,9 +469,9 @@ const HospitalityCleaning: React.FC = () => {
             <span className="pill-chip bg-white/10 text-white">
               <Sparkles className="h-4 w-4" /> Trusted by Brisbane venues
             </span>
-            <h2 className="section-heading__title text-white">Ready to elevate your guest experience?</h2>
+            <h2 className="section-heading__title text-white">Ready to elevate every guest touchpoint?</h2>
             <p className="section-heading__description text-white/80">
-              Book a walkthrough and receive a tailored hospitality cleaning program within 24 hours.
+              Book a walkthrough and receive a tailored scope, pricing and onboarding plan within 24 hours.
             </p>
             <div className="flex flex-col items-center justify-center gap-4 sm:flex-row sm:gap-6">
               <Link to="/contact" className="btn-primary">
@@ -508,6 +484,15 @@ const HospitalityCleaning: React.FC = () => {
           </div>
         </div>
       </section>
+
+      <StickyCTABar
+        title="Lock in five-star cleanliness"
+        description="Schedule a walkthrough today and secure your tailored hospitality program."
+        primaryLabel="Book my walkthrough"
+        primaryHref="/contact"
+        secondaryLabel="Call 0411 820 650"
+        secondaryHref="tel:+61411820650"
+      />
     </div>
   );
 };

--- a/src/pages/services/OfficesCleaning.tsx
+++ b/src/pages/services/OfficesCleaning.tsx
@@ -20,6 +20,7 @@ import PageHero from '../../components/PageHero';
 import QuoteSection from '../../components/QuoteSection';
 import HeroHighlightBand from '../../components/HeroHighlightBand';
 import HowItWorks from '../../components/HowItWorks';
+import StickyCTABar from '../../components/StickyCTABar';
 
 const OfficesCleaning: React.FC = () => {
   const inclusions = [
@@ -233,7 +234,7 @@ const OfficesCleaning: React.FC = () => {
   };
 
   return (
-    <div>
+    <div className="pb-32">
       <SEO
         title={pageTitle}
         description={pageDescription}
@@ -256,7 +257,7 @@ const OfficesCleaning: React.FC = () => {
         actions={
           <>
             <Link to="/contact" className="btn-primary">
-              Get a quote
+              Book your site walkthrough
             </Link>
             <a href="tel:+61411820650" className="btn-secondary">
               Call 0411 820 650
@@ -267,45 +268,14 @@ const OfficesCleaning: React.FC = () => {
 
       <HeroHighlightBand items={heroHighlights} />
 
-      <section className="section-shell" id="workplace-rhythm">
-        <div className="container-max mx-auto grid gap-10 lg:grid-cols-[1.1fr_1fr] lg:items-center">
-          <div className="space-y-6">
-            <div className="section-heading" data-align="left">
-              <span className="section-heading__eyebrow">Daily cadence</span>
-              <h2 className="section-heading__title">Cleaning schedules that mirror hybrid work patterns</h2>
-              <p className="section-heading__description">
-                We plot rosters around desk bookings, visitor arrivals and critical meetings so spaces stay presentation ready without disrupting productivity.
-              </p>
-            </div>
-            <ul className="space-y-4 text-jet/80">
-              <li className="flex items-start gap-3">
-                <Clock className="mt-1 h-5 w-5 text-celestial-blue-1" />
-                <span>Flexible shift options for early birds, day porters and overnight detail crews.</span>
-              </li>
-              <li className="flex items-start gap-3">
-                <Users className="mt-1 h-5 w-5 text-celestial-blue-1" />
-                <span>Alignment with building management and security for seamless access.</span>
-              </li>
-            </ul>
-          </div>
-          <div className="grid gap-4 sm:grid-cols-3">
-            {workplaceRhythms.map((rhythm) => (
-              <div key={rhythm.name} className="rounded-[32px] border border-white/40 bg-white p-6 text-center shadow-sm">
-                <h3 className="text-lg font-semibold text-charcoal">{rhythm.name}</h3>
-                <p className="mt-2 text-sm text-jet/80 leading-relaxed">{rhythm.description}</p>
-              </div>
-            ))}
-          </div>
-        </div>
-      </section>
-
       <section className="section-shell" id="pain-points">
         <div className="container-max mx-auto">
           <div className="section-heading">
-            <span className="section-heading__eyebrow">Your challenges</span>
-            <h2 className="section-heading__title">The reasons facility managers switch to us</h2>
+            <span className="section-heading__eyebrow">What you’re feeling</span>
+            <h2 className="section-heading__title">Facility teams call us when the basics keep slipping</h2>
             <p className="section-heading__description">
-              Office managers come to MOG Cleaning when inconsistency, poor presentation and slow responses start costing them credibility.
+              If desks are still dusty at 9am or boardrooms aren’t investor ready, it’s costing you credibility. We step in when you
+              need a partner who owns the presentation and the reporting.
             </p>
           </div>
           <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
@@ -322,65 +292,45 @@ const OfficesCleaning: React.FC = () => {
         </div>
       </section>
 
-      <section className="section-shell" id="solution">
-        <div className="container-max mx-auto grid gap-12 lg:grid-cols-2 lg:items-center">
-          <div className="glass-panel" data-variant="frost">
-            <img
-              src="/images/office-cleaning-background.jpg"
-              alt="Office cleaners detailing a Brisbane boardroom"
-              className="h-full w-full rounded-[32px] object-cover"
-              loading="lazy"
-              decoding="async"
-            />
-          </div>
+      <section className="section-shell" id="plan">
+        <div className="container-max mx-auto grid gap-12 lg:grid-cols-[1.15fr_1fr] lg:items-center">
           <div className="space-y-6">
             <div className="section-heading" data-align="left">
-              <span className="section-heading__eyebrow">Our solution</span>
-              <h2 className="section-heading__title">Structured office cleaning that protects your reputation</h2>
+              <span className="section-heading__eyebrow">Your plan</span>
+              <h2 className="section-heading__title">A 30-day turnaround that locks in consistency</h2>
               <p className="section-heading__description">
-                Dedicated corporate crews, supervisor audits and photo reporting keep your leadership team confident the moment they walk into the building.
+                We map your access requirements, design a floor-by-floor checklist and have induction-ready crews on site within
+                days. Every visit is documented so executives see the difference immediately.
               </p>
             </div>
             <ul className="space-y-4 text-jet/80">
               <li className="flex items-start gap-3">
-                <CheckCircle className="h-5 w-5 text-celestial-blue-1" />
-                <span>Custom scope by floor, including executive suites and shared amenities.</span>
+                <CheckCircle className="mt-1 h-5 w-5 text-celestial-blue-1" />
+                <span>Discovery walkthrough, scope build and stakeholder alignment in week one.</span>
               </li>
               <li className="flex items-start gap-3">
-                <CheckCircle className="h-5 w-5 text-celestial-blue-1" />
-                <span>After-hours scheduling that keeps your staff productive and undisturbed.</span>
+                <Users className="mt-1 h-5 w-5 text-celestial-blue-1" />
+                <span>Dedicated crew allocations with supervisor oversight for each floor plate.</span>
               </li>
               <li className="flex items-start gap-3">
-                <CheckCircle className="h-5 w-5 text-celestial-blue-1" />
-                <span>Inductions, SWMS and insurance certificates supplied before the first shift.</span>
+                <Clock className="mt-1 h-5 w-5 text-celestial-blue-1" />
+                <span>Rhythms that mirror hybrid work patterns so desks, amenities and client areas stay on point.</span>
               </li>
             </ul>
             <div className="flex flex-wrap gap-4">
               <Link to="/contact" className="btn-primary">
-                Book your walkthrough
+                Schedule my walkthrough
               </Link>
               <a href="tel:+61411820650" className="btn-secondary">
-                Call 0411 820 650
+                Speak to the team
               </a>
             </div>
           </div>
-        </div>
-      </section>
-
-      <section className="section-shell section-shell--muted" id="office-programs">
-        <div className="container-max mx-auto">
-          <div className="section-heading">
-            <span className="section-heading__eyebrow">Workplace zones</span>
-            <h2 className="section-heading__title">Playbooks for every corner of your office</h2>
-            <p className="section-heading__description">
-              Each zone receives a purpose-built checklist, from executive floors to end-of-trip facilities, so nothing is overlooked.
-            </p>
-          </div>
-          <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
-            {officePrograms.map((program) => (
-              <div key={program.title} className="rounded-[32px] bg-white p-8 shadow-sm">
-                <h3 className="text-2xl font-semibold text-charcoal">{program.title}</h3>
-                <p className="mt-3 text-jet/80 leading-relaxed">{program.copy}</p>
+          <div className="grid gap-4 sm:grid-cols-3">
+            {workplaceRhythms.map((rhythm) => (
+              <div key={rhythm.name} className="rounded-[32px] border border-white/40 bg-white p-6 text-center shadow-sm">
+                <h3 className="text-lg font-semibold text-charcoal">{rhythm.name}</h3>
+                <p className="mt-2 text-sm leading-relaxed text-jet/80">{rhythm.description}</p>
               </div>
             ))}
           </div>
@@ -388,13 +338,46 @@ const OfficesCleaning: React.FC = () => {
       </section>
 
       <HowItWorks
-        eyebrow="Your onboarding path"
-        title="Four steps from quote request to quality assured cleaning"
-        description="Every office client follows the same proven process so you know exactly what happens before day one."
+        eyebrow="How we onboard"
+        title="Four steps to a spotless corporate workspace"
+        description="From first walkthrough to ongoing QA, every stage is mapped so you can track progress and raise feedback instantly."
       />
 
+      <section className="section-shell section-shell--muted" id="office-programs">
+        <div className="container-max mx-auto">
+          <div className="section-heading">
+            <span className="section-heading__eyebrow">Tailored playbooks</span>
+            <h2 className="section-heading__title">Coverage for every space in your building</h2>
+            <p className="section-heading__description">
+              Executive suites, hybrid hubs and wellness zones each receive their own scope so your entire workplace looks intentional.
+            </p>
+          </div>
+          <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+            {officePrograms.map((program) => (
+              <div key={program.title} className="rounded-[32px] bg-white p-8 shadow-sm">
+                <h3 className="text-2xl font-semibold text-charcoal">{program.title}</h3>
+                <p className="mt-3 leading-relaxed text-jet/80">{program.copy}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="section-shell" id="results">
+        <div className="container-max mx-auto">
+          <div className="section-heading">
+            <span className="section-heading__eyebrow">Proof that sticks</span>
+            <h2 className="section-heading__title">Brisbane offices staying presentation-ready</h2>
+            <p className="section-heading__description">
+              See how facility teams describe the difference once MOG Cleaning takes over their corporate floors.
+            </p>
+          </div>
+          <TestimonialCarousel testimonials={testimonials} className="mx-auto max-w-4xl" />
+        </div>
+      </section>
+
       <QuoteSection
-        eyebrow="Start here"
+        eyebrow="Start your program"
         title="Request your office cleaning proposal"
         description="Share your floor count, key access notes and current pain points. We’ll prepare a tailored scope, onboarding timeline and pricing within 24 hours."
         bullets={[
@@ -409,7 +392,7 @@ const OfficesCleaning: React.FC = () => {
       <section className="section-shell" id="benefits">
         <div className="container-max mx-auto">
           <div className="section-heading">
-            <span className="section-heading__eyebrow">Why businesses switch to us</span>
+            <span className="section-heading__eyebrow">Why teams stay</span>
             <h2 className="section-heading__title">Outcomes for your people and presentation</h2>
             <p className="section-heading__description">
               We tailor programs that support productivity, impress stakeholders and keep your compliance documentation audit ready.
@@ -422,7 +405,7 @@ const OfficesCleaning: React.FC = () => {
                   <benefit.icon className="h-7 w-7" />
                 </div>
                 <h3 className="text-xl font-semibold text-charcoal">{benefit.title}</h3>
-                <p className="text-jet/80 leading-relaxed">{benefit.description}</p>
+                <p className="leading-relaxed text-jet/80">{benefit.description}</p>
               </div>
             ))}
           </div>
@@ -441,23 +424,10 @@ const OfficesCleaning: React.FC = () => {
           <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
             {inclusions.map((inclusion) => (
               <div key={inclusion} className="service-item p-6">
-                <p className="text-charcoal font-medium">{inclusion}</p>
+                <p className="font-medium text-charcoal">{inclusion}</p>
               </div>
             ))}
           </div>
-        </div>
-      </section>
-
-      <section className="section-shell" id="results">
-        <div className="container-max mx-auto">
-          <div className="section-heading">
-            <span className="section-heading__eyebrow">Client stories</span>
-            <h2 className="section-heading__title">Brisbane offices that trust MOG Cleaning</h2>
-            <p className="section-heading__description">
-              Hear from corporate partners who rely on us for consistent presentation and responsive support.
-            </p>
-          </div>
-          <TestimonialCarousel testimonials={testimonials} className="mx-auto max-w-4xl" />
         </div>
       </section>
 
@@ -470,7 +440,7 @@ const OfficesCleaning: React.FC = () => {
               Find out how we onboard security, manage keys and document every shift before confirming your contract.
             </p>
           </div>
-          <FAQAccordion faqs={faqs} className="max-w-4xl mx-auto" />
+          <FAQAccordion faqs={faqs} className="mx-auto max-w-4xl" />
         </div>
       </section>
 
@@ -518,6 +488,15 @@ const OfficesCleaning: React.FC = () => {
           </div>
         </div>
       </section>
+
+      <StickyCTABar
+        title="Ready to reclaim your mornings?"
+        description="Book a walkthrough today and lock in your tailored office cleaning program."
+        primaryLabel="Book my walkthrough"
+        primaryHref="/contact"
+        secondaryLabel="Call 0411 820 650"
+        secondaryHref="tel:+61411820650"
+      />
     </div>
   );
 };

--- a/src/pages/services/RetailCleaning.tsx
+++ b/src/pages/services/RetailCleaning.tsx
@@ -20,6 +20,7 @@ import PageHero from '../../components/PageHero';
 import QuoteSection from '../../components/QuoteSection';
 import HeroHighlightBand from '../../components/HeroHighlightBand';
 import HowItWorks from '../../components/HowItWorks';
+import StickyCTABar from '../../components/StickyCTABar';
 
 const RetailCleaning: React.FC = () => {
   const inclusions = [
@@ -231,30 +232,30 @@ const RetailCleaning: React.FC = () => {
   };
 
   return (
-    <div>
+    <div className="pb-32">
       <SEO
         title={pageTitle}
         description={pageDescription}
         type="service"
         image="/images/retail-cleaning-background.jpg"
-        imageAlt="Retail store being cleaned after hours"
-        keywords={['retail cleaning Brisbane', 'store cleaners brisbane', 'showroom cleaning services']}
+        imageAlt="Retail store being cleaned before opening"
+        keywords={['retail cleaning Brisbane', 'store cleaners', 'showroom cleaning services']}
         jsonLd={[breadcrumbSchema, serviceSchema]}
       />
 
       <PageHero
         backgroundImage="/images/retail-cleaning-background.jpg"
-        backgroundPosition="center 40%"
+        backgroundPosition="center"
         overlay="charcoal"
         align="center"
         eyebrow="Retail cleaning"
         eyebrowIcon={ShoppingBag}
-        title="Retail spaces that sell more with every spotless detail."
-        description="Protect your brand experience with crews who understand visual merchandising, customer flow and stockroom needs."
+        title="Keep every display, fitting room and back room retail ready."
+        description="Retail-trained cleaners who protect your visual merchandising, support staff and keep brand standards consistent."
         actions={
           <>
             <Link to="/contact" className="btn-primary">
-              Get a quote
+              Book a store walkthrough
             </Link>
             <a href="tel:+61411820650" className="btn-secondary">
               Call 0411 820 650
@@ -265,33 +266,13 @@ const RetailCleaning: React.FC = () => {
 
       <HeroHighlightBand items={heroHighlights} />
 
-      <section className="section-shell" id="seasonal-moments">
-        <div className="container-max mx-auto">
-          <div className="section-heading">
-            <span className="section-heading__eyebrow">Retail calendar</span>
-            <h2 className="section-heading__title">Programs that flex with your promotional moments</h2>
-            <p className="section-heading__description">
-              We build calendars that align with floor set changes, sales periods and extended trade so your store always looks launch ready.
-            </p>
-          </div>
-          <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
-            {seasonalMoments.map((moment) => (
-              <div key={moment.label} className="rounded-[32px] border border-white/40 bg-white p-8 shadow-sm">
-                <h3 className="text-xl font-semibold text-charcoal">{moment.label}</h3>
-                <p className="mt-3 text-jet/80 leading-relaxed">{moment.detail}</p>
-              </div>
-            ))}
-          </div>
-        </div>
-      </section>
-
       <section className="section-shell" id="pain-points">
         <div className="container-max mx-auto">
           <div className="section-heading">
-            <span className="section-heading__eyebrow">What’s at stake</span>
-            <h2 className="section-heading__title">Retail cleaning frustrations we solve</h2>
+            <span className="section-heading__eyebrow">Why retailers switch</span>
+            <h2 className="section-heading__title">Dust, streaks and clutter cost conversions</h2>
             <p className="section-heading__description">
-              From boutique stores to national brands, MOG Cleaning steps in when presentation and operations can’t afford to slip.
+              Retail leaders contact us when presentation slips or stockrooms become chaos. We restore showroom polish without slowing trade.
             </p>
           </div>
           <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
@@ -308,65 +289,44 @@ const RetailCleaning: React.FC = () => {
         </div>
       </section>
 
-      <section className="section-shell" id="solution">
-        <div className="container-max mx-auto grid gap-12 lg:grid-cols-2 lg:items-center">
-          <div className="glass-panel" data-variant="frost">
-            <img
-              src="/images/retail-cleaning-background.jpg"
-              alt="Cleaner wiping down retail display"
-              className="h-full w-full rounded-[32px] object-cover"
-              loading="lazy"
-              decoding="async"
-            />
-          </div>
+      <section className="section-shell" id="plan">
+        <div className="container-max mx-auto grid gap-12 lg:grid-cols-[1.15fr_1fr] lg:items-center">
           <div className="space-y-6">
             <div className="section-heading" data-align="left">
-              <span className="section-heading__eyebrow">Our approach</span>
-              <h2 className="section-heading__title">Brand-aligned cleaning for stores and showrooms</h2>
+              <span className="section-heading__eyebrow">Your plan</span>
+              <h2 className="section-heading__title">30 days to stores that always look launch ready</h2>
               <p className="section-heading__description">
-                We work with your retail operations team to keep displays, fitting rooms and stock areas running smoothly while you focus on customers.
+                We document every zone, align with centre management and onboard retail-trained crews. Daily reporting keeps head office and store teams confident.
               </p>
             </div>
             <ul className="space-y-4 text-jet/80">
               <li className="flex items-start gap-3">
-                <CheckCircle className="h-5 w-5 text-celestial-blue-1" />
-                <span>Detailed scopes for front-of-house, fitting rooms and back-of-house operations.</span>
+                <CheckCircle className="mt-1 h-5 w-5 text-celestial-blue-1" />
+                <span>Kick-off walkthrough with VM teams to capture fixtures, finishes and brand standards.</span>
               </li>
               <li className="flex items-start gap-3">
-                <CheckCircle className="h-5 w-5 text-celestial-blue-1" />
-                <span>After-hours scheduling and key management keep stores secure and ready for opening.</span>
+                <Users className="mt-1 h-5 w-5 text-celestial-blue-1" />
+                <span>Dedicated crews for trading floors, change rooms and back-of-house so nothing is overlooked.</span>
               </li>
               <li className="flex items-start gap-3">
-                <CheckCircle className="h-5 w-5 text-celestial-blue-1" />
-                <span>Reporting includes photo logs for head office visibility.</span>
+                <Clock className="mt-1 h-5 w-5 text-celestial-blue-1" />
+                <span>After-hours rosters and day porters to support launches, sale periods and late trade.</span>
               </li>
             </ul>
             <div className="flex flex-wrap gap-4">
               <Link to="/contact" className="btn-primary">
-                Book a store walkthrough
+                Schedule my store audit
               </Link>
               <a href="tel:+61411820650" className="btn-secondary">
-                Call 0411 820 650
+                Speak with retail support
               </a>
             </div>
           </div>
-        </div>
-      </section>
-
-      <section className="section-shell section-shell--muted" id="retail-support">
-        <div className="container-max mx-auto">
-          <div className="section-heading">
-            <span className="section-heading__eyebrow">Store formats</span>
-            <h2 className="section-heading__title">Support for every retail footprint</h2>
-            <p className="section-heading__description">
-              From boutique laneway stores to flagship showrooms, each site receives procedures specific to its fixtures, finishes and foot traffic.
-            </p>
-          </div>
-          <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
-            {retailSupport.map((item) => (
-              <div key={item.name} className="rounded-[32px] bg-white p-8 shadow-sm">
-                <h3 className="text-2xl font-semibold text-charcoal">{item.name}</h3>
-                <p className="mt-3 text-jet/80 leading-relaxed">{item.description}</p>
+          <div className="grid gap-4 sm:grid-cols-3">
+            {seasonalMoments.map((moment) => (
+              <div key={moment.label} className="rounded-[32px] border border-white/40 bg-white p-6 text-center shadow-sm">
+                <h3 className="text-lg font-semibold text-charcoal">{moment.label}</h3>
+                <p className="mt-2 text-sm leading-relaxed text-jet/80">{moment.detail}</p>
               </div>
             ))}
           </div>
@@ -374,31 +334,64 @@ const RetailCleaning: React.FC = () => {
       </section>
 
       <HowItWorks
-        eyebrow="Implementation"
-        title="Four steps to launch your retail cleaning program"
-        description="A streamlined process keeps your support office, store managers and operations team aligned."
+        eyebrow="How onboarding works"
+        title="Four steps to retail-ready presentation"
+        description="From scope capture to live reporting, our process keeps store managers and head office aligned."
       />
 
+      <section className="section-shell section-shell--muted" id="retail-support">
+        <div className="container-max mx-auto">
+          <div className="section-heading">
+            <span className="section-heading__eyebrow">Store formats</span>
+            <h2 className="section-heading__title">Programs for every retail footprint</h2>
+            <p className="section-heading__description">
+              Flagship stores, boutiques and showrooms all receive tailored checklists, access plans and reporting cadence.
+            </p>
+          </div>
+          <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+            {retailSupport.map((support) => (
+              <div key={support.name} className="rounded-[32px] bg-white p-8 shadow-sm">
+                <h3 className="text-2xl font-semibold text-charcoal">{support.name}</h3>
+                <p className="mt-3 leading-relaxed text-jet/80">{support.description}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="section-shell" id="testimonials">
+        <div className="container-max mx-auto">
+          <div className="section-heading">
+            <span className="section-heading__eyebrow">Proof for your retail ops team</span>
+            <h2 className="section-heading__title">Brands that trust MOG Cleaning</h2>
+            <p className="section-heading__description">
+              Hear how multi-site managers describe the uplift in store presentation and communication.
+            </p>
+          </div>
+          <TestimonialCarousel testimonials={testimonials} className="mx-auto max-w-4xl" />
+        </div>
+      </section>
+
       <QuoteSection
-        eyebrow="Start today"
+        eyebrow="Start your program"
         title="Request your retail cleaning proposal"
-        description="Tell us about your store footprint, trading hours and compliance expectations. We’ll provide a tailored scope within 24 hours."
+        description="Share your store count, trading hours and current challenges. We’ll deliver a tailored scope, onboarding plan and pricing within 24 hours."
         bullets={[
-          'After-hours crews for uninterrupted trading',
-          'Store-specific checklists and reporting',
-          'Support for visual merchandising resets',
+          'Retail-trained crews with security clearances',
+          'After-hours rosters and day porter options',
+          'Photo reporting for head office visibility',
         ]}
-        formTitle="Tell us about your store"
-        formSubtitle="Your retail account manager will respond within one business day."
+        formTitle="Tell us about your stores"
+        formSubtitle="Your dedicated retail contact will respond within one business day."
       />
 
       <section className="section-shell" id="benefits">
         <div className="container-max mx-auto">
           <div className="section-heading">
-            <span className="section-heading__eyebrow">Benefits</span>
-            <h2 className="section-heading__title">Why retail brands choose MOG Cleaning</h2>
+            <span className="section-heading__eyebrow">Why retailers stay</span>
+            <h2 className="section-heading__title">Outcomes for your team, customers and brand</h2>
             <p className="section-heading__description">
-              We help store teams focus on sales by removing cleaning headaches and protecting brand standards.
+              Consistent presentation, organised back rooms and confident staff keep conversion rates and NPS high.
             </p>
           </div>
           <div className="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-4">
@@ -408,7 +401,7 @@ const RetailCleaning: React.FC = () => {
                   <benefit.icon className="h-7 w-7" />
                 </div>
                 <h3 className="text-xl font-semibold text-charcoal">{benefit.title}</h3>
-                <p className="text-jet/80 leading-relaxed">{benefit.description}</p>
+                <p className="leading-relaxed text-jet/80">{benefit.description}</p>
               </div>
             ))}
           </div>
@@ -421,29 +414,16 @@ const RetailCleaning: React.FC = () => {
             <span className="section-heading__eyebrow">What’s included</span>
             <h2 className="section-heading__title">Retail cleaning checklist</h2>
             <p className="section-heading__description">
-              Every service is mapped to your store layout so presentation, change rooms and stock areas stay on point.
+              Every visit follows a documented scope so displays, fitting rooms and back rooms stay ready to trade.
             </p>
           </div>
           <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
             {inclusions.map((inclusion) => (
               <div key={inclusion} className="service-item p-6">
-                <p className="text-charcoal font-medium">{inclusion}</p>
+                <p className="font-medium text-charcoal">{inclusion}</p>
               </div>
             ))}
           </div>
-        </div>
-      </section>
-
-      <section className="section-shell" id="testimonials">
-        <div className="container-max mx-auto">
-          <div className="section-heading">
-            <span className="section-heading__eyebrow">Results</span>
-            <h2 className="section-heading__title">What Brisbane retailers say</h2>
-            <p className="section-heading__description">
-              Hear from state and store managers who rely on MOG Cleaning to keep stores customer-ready.
-            </p>
-          </div>
-          <TestimonialCarousel testimonials={testimonials} className="mx-auto max-w-4xl" />
         </div>
       </section>
 
@@ -453,20 +433,20 @@ const RetailCleaning: React.FC = () => {
             <span className="section-heading__eyebrow">FAQs</span>
             <h2 className="section-heading__title">Retail cleaning FAQs</h2>
             <p className="section-heading__description">
-              See how we handle opening routines, promotional changeovers and national reporting before you book your walkthrough.
+              Learn how we coordinate with centre management, access requirements and after-hours schedules before you engage us.
             </p>
           </div>
-          <FAQAccordion faqs={faqs} className="max-w-4xl mx-auto" />
+          <FAQAccordion faqs={faqs} className="mx-auto max-w-4xl" />
         </div>
       </section>
 
       <section className="section-shell section-shell--muted" id="related">
         <div className="container-max mx-auto">
           <div className="section-heading">
-            <span className="section-heading__eyebrow">Explore more programs</span>
-            <h2 className="section-heading__title">Extend spotless standards everywhere</h2>
+            <span className="section-heading__eyebrow">Need something else?</span>
+            <h2 className="section-heading__title">Explore other services</h2>
             <p className="section-heading__description">
-              Keep your entire brand ecosystem aligned by partnering with MOG Cleaning across venues and offices.
+              From hospitality to offices, we bring the same attentive crews and transparent reporting to every site.
             </p>
           </div>
           <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
@@ -487,11 +467,11 @@ const RetailCleaning: React.FC = () => {
         <div className="container-max mx-auto text-center">
           <div className="mx-auto max-w-3xl space-y-6">
             <span className="pill-chip bg-white/10 text-white">
-              <Sparkles className="h-4 w-4" /> Trusted by Brisbane retailers
+              <Sparkles className="h-4 w-4" /> Trusted by national retailers
             </span>
-            <h2 className="section-heading__title text-white">Ready to keep shoppers impressed?</h2>
+            <h2 className="section-heading__title text-white">Ready to unlock higher conversion rates?</h2>
             <p className="section-heading__description text-white/80">
-              Book a walkthrough and receive a tailored retail cleaning program within 24 hours.
+              Book a walkthrough and receive a tailored scope, pricing and onboarding plan within 24 hours.
             </p>
             <div className="flex flex-col items-center justify-center gap-4 sm:flex-row sm:gap-6">
               <Link to="/contact" className="btn-primary">
@@ -504,6 +484,15 @@ const RetailCleaning: React.FC = () => {
           </div>
         </div>
       </section>
+
+      <StickyCTABar
+        title="Keep every store photo-ready"
+        description="Book a walkthrough to secure your tailored retail cleaning program."
+        primaryLabel="Book my walkthrough"
+        primaryHref="/contact"
+        secondaryLabel="Call 0411 820 650"
+        secondaryHref="tel:+61411820650"
+      />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- Restructured each industry service page around a problem-solution-proof narrative with clearer CTAs and quote prompts.
- Added a reusable sticky CTA bar component to keep contact and call actions visible on long-scroll pages.
- Updated copy, section order, and supporting content to create a cohesive conversion-focused journey for all service verticals.

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e26abb93ec83279f417ee840001d43