### PR TITLE
Refine mobile responsiveness across pages

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -916,6 +916,18 @@ h6 {
   @apply grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6;
 }
 
+.testimonial-carousel {
+  isolation: isolate;
+}
+
+.testimonial-carousel__track {
+  will-change: transform;
+}
+
+.testimonial-carousel__quote {
+  text-wrap: pretty;
+}
+
 /* Improved responsive text sizing */
 .hero-title {
   @apply text-3xl sm:text-4xl md:text-5xl lg:text-6xl font-bold leading-tight;
@@ -1076,6 +1088,274 @@ h6 {
 }
 
 @media (max-width: 767px) {
+  html,
+  body {
+    overflow-x: hidden;
+  }
+
+  body {
+    font-size: 15px;
+    line-height: 1.7;
+    letter-spacing: 0.01em;
+  }
+
+  main,
+  .page-shell {
+    width: 100%;
+    overflow-x: clip;
+  }
+
+  .container-max {
+    padding-inline: clamp(1.25rem, 5vw, 1.75rem);
+  }
+
+  .hero-section-spacing {
+    padding-top: clamp(5.5rem, 8vw + 2.9rem, 6.75rem);
+    padding-bottom: clamp(3.8rem, 10vw, 4.9rem);
+  }
+
+  .hero-minimal {
+    min-height: auto;
+    align-items: flex-end;
+  }
+
+  .hero-minimal__container {
+    padding-inline: clamp(1.1rem, 5vw, 1.5rem);
+  }
+
+  .hero-minimal__content {
+    align-items: flex-start;
+    text-align: left;
+    gap: 1.2rem;
+  }
+
+  .hero-minimal__title {
+    font-size: clamp(2.2rem, 6vw + 1rem, 3rem);
+    text-wrap: balance;
+  }
+
+  .hero-minimal__description {
+    font-size: 1rem;
+    line-height: 1.75;
+    color: rgba(230, 240, 250, 0.92);
+    -webkit-line-clamp: unset;
+    display: block;
+    text-wrap: pretty;
+  }
+
+  .hero-minimal__cta-group {
+    align-items: stretch;
+    gap: 1.1rem;
+  }
+
+  .hero-minimal__cta-buttons {
+    width: 100%;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.75rem;
+  }
+
+  .hero-minimal__cta-buttons .btn-primary,
+  .hero-minimal__cta-buttons .btn-ghost {
+    width: 100%;
+  }
+
+  .hero-minimal__cta-note {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .hero-minimal__assurances {
+    width: 100%;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.65rem;
+  }
+
+  .hero-minimal__assurance {
+    justify-content: flex-start;
+    padding: 0.65rem 1rem;
+    border-radius: 18px;
+    background: rgba(6, 20, 36, 0.3);
+    font-size: 0.92rem;
+  }
+
+  .feature-ticker {
+    left: 0;
+    right: auto;
+    width: 100%;
+    margin-left: 0;
+    margin-right: 0;
+    border-radius: 24px;
+    padding-inline: clamp(1.1rem, 4vw, 1.5rem);
+  }
+
+  .hero-highlight-band {
+    margin-inline: clamp(1rem, 5vw, 1.5rem);
+    border-radius: 26px;
+  }
+
+  .hero-highlight-band .container-max {
+    padding-inline: 0;
+  }
+
+  .hero-highlight-card::after {
+    content: none;
+  }
+
+  .hero-highlight-band__grid {
+    gap: clamp(1.1rem, 4vw, 1.8rem);
+  }
+
+  .section-shell {
+    padding: clamp(3rem, 6vw + 1.5rem, 3.8rem) clamp(1.1rem, 5vw, 1.5rem);
+  }
+
+  .section-heading {
+    text-align: left;
+    margin-bottom: 2.4rem;
+  }
+
+  .section-heading__title {
+    font-size: clamp(1.95rem, 7vw + 0.8rem, 2.5rem);
+    line-height: 1.2;
+    text-wrap: balance;
+  }
+
+  .section-heading__description {
+    font-size: 1rem;
+    line-height: 1.7;
+    text-wrap: pretty;
+  }
+
+  .stat-grid {
+    gap: 1.35rem;
+  }
+
+  .stat-card,
+  .feature-grid-card {
+    padding: clamp(1.45rem, 5vw, 1.9rem);
+    border-radius: 22px;
+  }
+
+  .glass-panel {
+    margin-top: 2rem;
+  }
+
+  .stat-card__value {
+    font-size: clamp(2rem, 8vw, 2.8rem);
+  }
+
+  .stat-card__description,
+  .service-card__description,
+  .service-card__list li,
+  .testimonial-carousel__quote,
+  .site-footer__subtitle {
+    text-wrap: pretty;
+  }
+
+  .service-card {
+    border-radius: 24px;
+  }
+
+  .service-card__visual {
+    aspect-ratio: 5 / 4;
+  }
+
+  .service-card__badge {
+    left: 1rem;
+    bottom: 1rem;
+  }
+
+  .service-card__body {
+    padding: 1.6rem 1.3rem 1.9rem;
+    gap: 1rem;
+  }
+
+  .testimonial-carousel {
+    border-radius: 26px;
+    padding: 2.25rem 1.5rem;
+  }
+
+  .testimonial-carousel__intro {
+    align-items: flex-start;
+    gap: 1.1rem;
+    text-align: left;
+  }
+
+  .testimonial-carousel__intro-rating,
+  .testimonial-carousel__intro-meta {
+    justify-content: flex-start;
+  }
+
+  .testimonial-carousel__quote {
+    font-size: 1.12rem;
+    line-height: 1.75;
+  }
+
+  .testimonial-carousel__nav {
+    width: 100%;
+    justify-content: space-between;
+    gap: 0.75rem;
+  }
+
+  .testimonial-carousel__nav-button {
+    height: 3rem;
+    width: 3rem;
+  }
+
+  .quote-section {
+    padding: clamp(1.75rem, 5vw, 2.3rem);
+    border-radius: 26px;
+    background: rgba(255, 255, 255, 0.92);
+  }
+
+  .quote-section::before {
+    content: none;
+  }
+
+  .quote-section__copy {
+    gap: 1rem;
+  }
+
+  .quote-section__title {
+    font-size: clamp(1.7rem, 6vw + 0.8rem, 2.1rem);
+  }
+
+  .quote-section__list {
+    gap: 0.6rem;
+  }
+
+  .quote-section__form {
+    width: 100%;
+  }
+
+  .faq-accordion-card {
+    padding: 1.6rem 1.4rem;
+  }
+
+  .site-footer__container {
+    padding-inline: clamp(1.25rem, 5vw, 1.75rem);
+  }
+
+  .site-footer__brand-card {
+    padding: 1.8rem 1.6rem;
+  }
+
+  .site-footer__contact-list {
+    gap: 0.75rem;
+  }
+
+  .site-footer__subtitle {
+    font-size: 0.98rem;
+    line-height: 1.65;
+  }
+
+  .site-footer__glow--one,
+  .site-footer__glow--two {
+    display: none;
+  }
+
   .faq-stack .faq-card {
     margin-top: 0 !important;
     opacity: 1;

--- a/src/components/ChecklistPreview.tsx
+++ b/src/components/ChecklistPreview.tsx
@@ -38,7 +38,10 @@ const ChecklistPreview: React.FC<ChecklistPreviewProps> = ({
         </p>
         <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
           {categories.map((category) => (
-            <div key={category.title} className="rounded-[32px] bg-white p-8 shadow-sm">
+            <div
+              key={category.title}
+              className="rounded-[28px] bg-white p-6 shadow-sm sm:rounded-[32px] sm:p-8"
+            >
               <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-celestial-blue-1/12 text-celestial-blue-1">
                 <category.icon className="h-6 w-6" />
               </div>

--- a/src/components/QuoteForm.tsx
+++ b/src/components/QuoteForm.tsx
@@ -73,7 +73,7 @@ const QuoteForm: React.FC<QuoteFormProps> = ({
 
   return (
     <div
-      className={`relative overflow-hidden rounded-[32px] border border-white/50 bg-white/95 p-8 shadow-[0_35px_60px_-25px_rgba(15,23,42,0.55)] backdrop-blur ${className}`}
+      className={`relative overflow-hidden rounded-[28px] border border-white/50 bg-white/95 p-6 shadow-[0_35px_60px_-25px_rgba(15,23,42,0.55)] backdrop-blur sm:rounded-[32px] sm:p-8 ${className}`}
     >
       <div className="pointer-events-none absolute -top-28 right-0 h-48 w-48 rounded-full bg-celestial-blue-1/25 blur-3xl"></div>
       <div className="pointer-events-none absolute -bottom-16 left-6 h-40 w-40 rounded-full bg-fresh-green/20 blur-3xl"></div>

--- a/src/components/TestimonialCarousel.tsx
+++ b/src/components/TestimonialCarousel.tsx
@@ -112,20 +112,26 @@ const TestimonialCarousel: React.FC<TestimonialCarouselProps> = ({
 
   return (
     <div
-      className={`relative overflow-hidden rounded-[32px] border border-white/60 bg-gradient-to-br from-white via-white to-celestial-blue-1/12 p-6 sm:p-12 shadow-2xl backdrop-blur-sm ${className}`}
+      className={`testimonial-carousel relative overflow-hidden rounded-[32px] border border-white/60 bg-gradient-to-br from-white via-white to-celestial-blue-1/12 p-6 sm:p-12 shadow-2xl backdrop-blur-sm ${className}`}
     >
-      <div className="absolute -top-24 -right-16 h-64 w-64 rounded-full bg-celestial-blue-1/15 blur-3xl" aria-hidden="true"></div>
-      <div className="absolute -bottom-28 -left-20 h-72 w-72 rounded-full bg-fresh-green/12 blur-3xl" aria-hidden="true"></div>
+      <div
+        className="absolute hidden h-64 w-64 rounded-full bg-celestial-blue-1/15 blur-3xl sm:block sm:-top-24 sm:-right-16"
+        aria-hidden="true"
+      ></div>
+      <div
+        className="absolute hidden h-72 w-72 rounded-full bg-fresh-green/12 blur-3xl sm:block sm:-bottom-28 sm:-left-20"
+        aria-hidden="true"
+      ></div>
 
       <div className="relative z-10">
-        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between mb-10 text-center sm:text-left">
-          <div className="flex items-center justify-center sm:justify-start gap-2 text-celestial-blue-1">
+        <div className="testimonial-carousel__intro mb-10 flex flex-col gap-4 text-center sm:flex-row sm:items-center sm:justify-between sm:text-left">
+          <div className="testimonial-carousel__intro-rating flex items-center justify-center gap-2 text-celestial-blue-1 sm:justify-start">
             {Array.from({ length: 5 }).map((_, index) => (
               <Star key={`star-${index}`} className="h-5 w-5 fill-celestial-blue-1 text-celestial-blue-1" />
             ))}
             <span className="text-sm font-semibold text-celestial-blue-1/80">Trusted by Brisbane businesses</span>
           </div>
-          <div className="flex items-center justify-center sm:justify-end gap-3">
+          <div className="testimonial-carousel__intro-meta flex items-center justify-center gap-3 sm:justify-end">
             <div className="rounded-full bg-white/80 p-3 shadow-inner">
               <MessageCircle className="h-6 w-6 text-celestial-blue-1" />
             </div>
@@ -136,13 +142,13 @@ const TestimonialCarousel: React.FC<TestimonialCarouselProps> = ({
         </div>
 
         <div
-          className="flex transition-transform duration-700 ease-out"
+          className="testimonial-carousel__track flex transition-transform duration-500 ease-out"
           style={{ transform: `translateX(-${activeIndex * 100}%)` }}
           aria-live="polite"
         >
           {slides.map((testimonial, index) => (
             <div key={`${testimonial.name}-${index}`} className="min-w-full flex-shrink-0 basis-full px-2">
-              <div className="mx-auto flex max-w-3xl flex-col justify-between px-2 sm:px-6 text-center md:text-left">
+              <div className="mx-auto flex max-w-3xl flex-col justify-between px-2 text-center sm:px-6 md:text-left">
                 {testimonial.highlight && (
                   <span className="mb-6 inline-block rounded-full bg-celestial-blue-1/10 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-celestial-blue-1/70">
                     {testimonial.highlight}
@@ -151,7 +157,7 @@ const TestimonialCarousel: React.FC<TestimonialCarouselProps> = ({
                 <div className="mb-6 flex justify-center md:justify-start">
                   <Quote className="h-8 w-8 text-celestial-blue-1/40" />
                 </div>
-                <p className="text-lg sm:text-2xl text-charcoal leading-relaxed mb-8">&ldquo;{testimonial.quote}&rdquo;</p>
+                <p className="testimonial-carousel__quote mb-8 text-lg leading-relaxed text-charcoal sm:text-2xl">&ldquo;{testimonial.quote}&rdquo;</p>
                 <div className="space-y-1">
                   <div className="text-lg font-semibold text-charcoal">{testimonial.name}</div>
                   <div className="text-sm text-jet/80">{testimonial.role}</div>
@@ -180,11 +186,11 @@ const TestimonialCarousel: React.FC<TestimonialCarouselProps> = ({
               <ChevronRight className="w-5 h-5" />
             </button>
 
-            <div className="mt-6 flex items-center justify-center gap-4 sm:hidden">
+            <div className="testimonial-carousel__nav mt-6 flex items-center justify-center gap-4 sm:hidden">
               <button
                 type="button"
                 onClick={goPrev}
-                className="flex h-12 w-12 items-center justify-center rounded-full border border-ash-gray/50 bg-white/95 text-charcoal shadow-md transition-colors hover:bg-celestial-blue-1 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-celestial-blue-1/80 focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+                className="testimonial-carousel__nav-button flex h-12 w-12 items-center justify-center rounded-full border border-ash-gray/50 bg-white/95 text-charcoal shadow-md transition-colors hover:bg-celestial-blue-1 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-celestial-blue-1/80 focus-visible:ring-offset-2 focus-visible:ring-offset-white"
                 aria-label="Previous testimonial"
               >
                 <ChevronLeft className="w-5 h-5" />
@@ -192,7 +198,7 @@ const TestimonialCarousel: React.FC<TestimonialCarouselProps> = ({
               <button
                 type="button"
                 onClick={goNext}
-                className="flex h-12 w-12 items-center justify-center rounded-full border border-ash-gray/50 bg-white/95 text-charcoal shadow-md transition-colors hover:bg-celestial-blue-1 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-celestial-blue-1/80 focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+                className="testimonial-carousel__nav-button flex h-12 w-12 items-center justify-center rounded-full border border-ash-gray/50 bg-white/95 text-charcoal shadow-md transition-colors hover:bg-celestial-blue-1 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-celestial-blue-1/80 focus-visible:ring-offset-2 focus-visible:ring-offset-white"
                 aria-label="Next testimonial"
               >
                 <ChevronRight className="w-5 h-5" />

--- a/src/pages/services/EducationCleaning.tsx
+++ b/src/pages/services/EducationCleaning.tsx
@@ -326,7 +326,10 @@ const EducationCleaning: React.FC = () => {
           </div>
           <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
             {campusZones.map((zone) => (
-              <div key={zone.title} className="rounded-[32px] bg-white p-8 shadow-sm">
+              <div
+                key={zone.title}
+                className="rounded-[28px] bg-white p-6 shadow-sm sm:rounded-[32px] sm:p-8"
+              >
                 <h3 className="text-2xl font-semibold text-charcoal">{zone.title}</h3>
                 <p className="mt-3 leading-relaxed text-jet/80">{zone.copy}</p>
               </div>

--- a/src/pages/services/FitnessCleaning.tsx
+++ b/src/pages/services/FitnessCleaning.tsx
@@ -325,7 +325,10 @@ const FitnessCleaning: React.FC = () => {
           </div>
           <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
             {studioPrograms.map((program) => (
-              <div key={program.name} className="rounded-[32px] bg-white p-8 shadow-sm">
+              <div
+                key={program.name}
+                className="rounded-[28px] bg-white p-6 shadow-sm sm:rounded-[32px] sm:p-8"
+              >
                 <h3 className="text-2xl font-semibold text-charcoal">{program.name}</h3>
                 <p className="mt-3 leading-relaxed text-jet/80">{program.detail}</p>
               </div>

--- a/src/pages/services/HealthCleaning.tsx
+++ b/src/pages/services/HealthCleaning.tsx
@@ -326,7 +326,10 @@ const HealthCleaning: React.FC = () => {
           </div>
           <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
             {clinicalSpaces.map((space) => (
-              <div key={space.name} className="rounded-[32px] bg-white p-8 shadow-sm">
+              <div
+                key={space.name}
+                className="rounded-[28px] bg-white p-6 shadow-sm sm:rounded-[32px] sm:p-8"
+              >
                 <h3 className="text-2xl font-semibold text-charcoal">{space.name}</h3>
                 <p className="mt-3 leading-relaxed text-jet/80">{space.detail}</p>
               </div>

--- a/src/pages/services/HospitalityCleaning.tsx
+++ b/src/pages/services/HospitalityCleaning.tsx
@@ -326,7 +326,10 @@ const HospitalityCleaning: React.FC = () => {
           </div>
           <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
             {venueBoards.map((board) => (
-              <div key={board.title} className="rounded-[32px] bg-white p-8 shadow-sm">
+              <div
+                key={board.title}
+                className="rounded-[28px] bg-white p-6 shadow-sm sm:rounded-[32px] sm:p-8"
+              >
                 <h3 className="text-2xl font-semibold text-charcoal">{board.title}</h3>
                 <p className="mt-3 leading-relaxed text-jet/80">{board.body}</p>
               </div>

--- a/src/pages/services/OfficesCleaning.tsx
+++ b/src/pages/services/OfficesCleaning.tsx
@@ -327,7 +327,10 @@ const OfficesCleaning: React.FC = () => {
           </div>
           <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
             {officePrograms.map((program) => (
-              <div key={program.title} className="rounded-[32px] bg-white p-8 shadow-sm">
+              <div
+                key={program.title}
+                className="rounded-[28px] bg-white p-6 shadow-sm sm:rounded-[32px] sm:p-8"
+              >
                 <h3 className="text-2xl font-semibold text-charcoal">{program.title}</h3>
                 <p className="mt-3 leading-relaxed text-jet/80">{program.copy}</p>
               </div>

--- a/src/pages/services/RetailCleaning.tsx
+++ b/src/pages/services/RetailCleaning.tsx
@@ -326,7 +326,10 @@ const RetailCleaning: React.FC = () => {
           </div>
           <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
             {retailSupport.map((support) => (
-              <div key={support.name} className="rounded-[32px] bg-white p-8 shadow-sm">
+              <div
+                key={support.name}
+                className="rounded-[28px] bg-white p-6 shadow-sm sm:rounded-[32px] sm:p-8"
+              >
                 <h3 className="text-2xl font-semibold text-charcoal">{support.name}</h3>
                 <p className="mt-3 leading-relaxed text-jet/80">{support.description}</p>
               </div>


### PR DESCRIPTION
## Summary
- tighten mobile overflow handling and spacing for hero, highlight, quote, and footer sections so the mobile layout stays centered without horizontal gaps
- hide decorative testimonial glows on small screens and adjust shared form/checklist cards for touch-friendly padding
- update each industry service page to reuse the responsive card spacing for their program previews

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e39d3975b083278cd3398087961a01