### PR TITLE
Improve mobile services carousel and quote form responsiveness

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1274,6 +1274,108 @@ h6 {
     gap: 1rem;
   }
 
+  .services-carousel {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+    margin-top: 0.75rem;
+  }
+
+  .services-carousel__header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1rem;
+  }
+
+  .services-carousel__copy {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .services-carousel__title {
+    margin: 0;
+    font-size: 1.2rem;
+    font-weight: 700;
+    color: #0a2233;
+    text-wrap: balance;
+  }
+
+  .services-carousel__description {
+    margin-top: 0.45rem;
+    font-size: 0.95rem;
+    line-height: 1.55;
+    color: rgba(9, 32, 53, 0.72);
+    text-wrap: pretty;
+  }
+
+  .services-carousel__controls {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+  }
+
+  .services-carousel__control {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.75rem;
+    height: 2.75rem;
+    border-radius: 999px;
+    border: 1px solid rgba(13, 161, 225, 0.3);
+    background: rgba(255, 255, 255, 0.96);
+    color: #0da1e1;
+    box-shadow: 0 24px 46px -32px rgba(5, 31, 52, 0.48);
+    transition: background 0.3s ease, color 0.3s ease, border-color 0.3s ease;
+  }
+
+  .services-carousel__control:active {
+    background: rgba(13, 161, 225, 0.12);
+  }
+
+  .services-carousel__control:focus-visible {
+    outline: 3px solid rgba(13, 161, 225, 0.35);
+    outline-offset: 3px;
+  }
+
+  .services-carousel__track {
+    display: flex;
+    gap: 1.15rem;
+    overflow-x: auto;
+    padding-bottom: 0.5rem;
+    margin-inline: -0.25rem;
+    padding-inline: 0.25rem;
+    scroll-snap-type: x mandatory;
+    scroll-padding-left: 0.25rem;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .services-carousel__track::-webkit-scrollbar {
+    display: none;
+  }
+
+  .services-carousel__card {
+    flex: 0 0 82%;
+    min-width: 82%;
+    scroll-snap-align: start;
+  }
+
+  .services-carousel__card .service-card__title {
+    font-size: 1.35rem;
+  }
+
+  .services-carousel__card .service-card__description {
+    font-size: 0.98rem;
+  }
+
+  .services-carousel__hint {
+    margin: 0;
+    font-size: 0.85rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: rgba(9, 32, 53, 0.58);
+  }
+
   .testimonial-carousel {
     border-radius: 26px;
     padding: 2.25rem 1.5rem;
@@ -1330,6 +1432,49 @@ h6 {
 
   .quote-section__form {
     width: 100%;
+  }
+
+  .quote-form {
+    padding: 1.9rem 1.45rem;
+    border-radius: 22px;
+  }
+
+  .quote-form__header {
+    align-items: flex-start;
+    text-align: left;
+    gap: 1.2rem;
+  }
+
+  .quote-form__intro {
+    width: 100%;
+  }
+
+  .quote-form__title {
+    font-size: 1.6rem !important;
+    line-height: 1.25;
+  }
+
+  .quote-form__subtitle {
+    font-size: 0.95rem !important;
+    line-height: 1.6;
+  }
+
+  .quote-form__badge {
+    align-self: flex-start;
+    padding-inline: 0.85rem;
+    padding-block: 0.55rem;
+    font-size: 0.65rem;
+    letter-spacing: 0.26em;
+  }
+
+  .quote-form input,
+  .quote-form textarea {
+    font-size: 1rem;
+  }
+
+  .quote-form button {
+    font-size: 1rem;
+    padding-block: 0.9rem;
   }
 
   .faq-accordion-card {

--- a/src/components/QuoteForm.tsx
+++ b/src/components/QuoteForm.tsx
@@ -79,12 +79,12 @@ const QuoteForm: React.FC<QuoteFormProps> = ({
       <div className="pointer-events-none absolute -bottom-16 left-6 h-40 w-40 rounded-full bg-fresh-green/20 blur-3xl"></div>
 
       <div className="relative">
-        <div className="flex flex-col items-center gap-4 text-center sm:flex-row sm:items-center sm:justify-between sm:gap-5 sm:text-left">
-          <div>
-            <h3 className="text-2xl font-bold text-charcoal sm:text-[1.65rem]">{title}</h3>
-            <p className="mt-1 text-sm text-jet/80 sm:text-base">{subtitle}</p>
+        <div className="quote-form__header flex flex-col items-center gap-4 text-center sm:flex-row sm:items-center sm:justify-between sm:gap-5 sm:text-left">
+          <div className="quote-form__intro">
+            <h3 className="quote-form__title text-2xl font-bold text-charcoal sm:text-[1.65rem]">{title}</h3>
+            <p className="quote-form__subtitle mt-1 text-sm text-jet/80 sm:text-base">{subtitle}</p>
           </div>
-          <div className="inline-flex items-center justify-center gap-2 rounded-full border border-ash-gray/40 bg-white/85 px-4 py-2 text-[0.7rem] font-semibold uppercase tracking-[0.3em] text-charcoal/70 shadow-sm sm:self-center">
+          <div className="quote-form__badge inline-flex items-center justify-center gap-2 rounded-full border border-ash-gray/40 bg-white/85 px-4 py-2 text-[0.7rem] font-semibold uppercase tracking-[0.3em] text-charcoal/70 shadow-sm sm:self-center">
             <span className="whitespace-nowrap">24hr Reply</span>
           </div>
         </div>
@@ -104,6 +104,7 @@ const QuoteForm: React.FC<QuoteFormProps> = ({
                 onChange={handleChange}
                 className={inputClasses}
                 placeholder="Your full name"
+                autoComplete="name"
               />
             </div>
 
@@ -120,6 +121,8 @@ const QuoteForm: React.FC<QuoteFormProps> = ({
                 onChange={handleChange}
                 className={inputClasses}
                 placeholder="0411 820 650"
+                autoComplete="tel"
+                inputMode="tel"
               />
             </div>
           </div>
@@ -137,6 +140,7 @@ const QuoteForm: React.FC<QuoteFormProps> = ({
               onChange={handleChange}
               className={inputClasses}
               placeholder="your.email@company.com"
+              autoComplete="email"
             />
           </div>
 
@@ -152,6 +156,7 @@ const QuoteForm: React.FC<QuoteFormProps> = ({
               onChange={handleChange}
               className={`${inputClasses} min-h-[140px] resize-none sm:min-h-[170px]`}
               placeholder="Facility type, approximate size, frequency required, any compliance notes."
+              autoComplete="off"
             ></textarea>
           </div>
 

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Link } from 'react-router-dom';
 import {
   Shield,
@@ -6,6 +6,7 @@ import {
   Users,
   CheckCircle,
   Star,
+  ArrowLeft,
   ArrowRight,
   Building2,
   Dumbbell,
@@ -31,6 +32,20 @@ import HowItWorks from '../components/HowItWorks';
 
 const Home: React.FC = () => {
   const scrollToServices = useScrollToSection('services');
+  const servicesCarouselRef = useRef<HTMLDivElement | null>(null);
+
+  const scrollServicesCarousel = (direction: 'previous' | 'next') => {
+    const node = servicesCarouselRef.current;
+    if (!node) {
+      return;
+    }
+
+    const scrollAmount = node.clientWidth * 0.88;
+    node.scrollBy({
+      left: direction === 'next' ? scrollAmount : -scrollAmount,
+      behavior: 'smooth',
+    });
+  };
 
   const heroHighlights = [
     {
@@ -466,7 +481,71 @@ const Home: React.FC = () => {
               Choose the program tailored to your industry. Each page highlights the specifics, results and pricing guidance you need.
             </p>
           </div>
-          <div className="grid grid-cols-1 gap-8 md:grid-cols-2 xl:grid-cols-3">
+          <div className="services-carousel md:hidden" aria-label="Swipeable list of cleaning service programs">
+            <div className="services-carousel__header">
+              <div className="services-carousel__copy">
+                <h3 className="services-carousel__title">Swipe through our specialist programs</h3>
+                <p className="services-carousel__description">
+                  Slide sideways or tap the arrows to browse each industry-specific cleaning pathway.
+                </p>
+              </div>
+              <div className="services-carousel__controls" role="group" aria-label="Service carousel controls">
+                <button
+                  type="button"
+                  className="services-carousel__control"
+                  aria-label="View previous service"
+                  onClick={() => scrollServicesCarousel('previous')}
+                >
+                  <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+                </button>
+                <button
+                  type="button"
+                  className="services-carousel__control"
+                  aria-label="View next service"
+                  onClick={() => scrollServicesCarousel('next')}
+                >
+                  <ArrowRight className="h-4 w-4" aria-hidden="true" />
+                </button>
+              </div>
+            </div>
+            <div
+              ref={servicesCarouselRef}
+              className="services-carousel__track"
+              aria-live="polite"
+              aria-describedby="services-carousel-hint"
+            >
+              {services.map((service) => (
+                <Link key={service.name} to={service.path} className="service-card group services-carousel__card">
+                  <div className="service-card__visual">
+                    <img
+                      src={service.image}
+                      alt={`${service.name} cleaning in Brisbane`}
+                      className="service-card__image"
+                      loading="lazy"
+                      decoding="async"
+                    />
+                    <span className="service-card__badge">
+                      <service.icon className="h-4 w-4" aria-hidden="true" />
+                      {service.name}
+                    </span>
+                  </div>
+                  <div className="service-card__body">
+                    <span className="service-card__eyebrow">Tailored program</span>
+                    <h3 className="service-card__title">{service.name}</h3>
+                    <p className="service-card__description">{service.description}</p>
+                    <span className="service-card__cta">
+                      Explore program
+                      <ArrowRight className="h-4 w-4" aria-hidden="true" />
+                    </span>
+                  </div>
+                </Link>
+              ))}
+            </div>
+            <p id="services-carousel-hint" className="services-carousel__hint">
+              Swipe left or right to see more industries.
+            </p>
+          </div>
+          <div className="hidden gap-8 md:grid md:grid-cols-2 xl:grid-cols-3">
             {services.map((service) => (
               <Link key={service.name} to={service.path} className="service-card group">
                 <div className="service-card__visual">


### PR DESCRIPTION
## Summary
- add a mobile-only swipeable services carousel with explicit controls and guidance while keeping the desktop grid intact
- refine mobile typography and spacing for services and quote sections to prevent overlap and improve readability
- enhance the quote form for handheld use with layout hooks and mobile-friendly autofill attributes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3a760c0988327bc875d74f485e7f7