### PR TITLE
Polish mobile hero spacing and service carousel

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -214,10 +214,17 @@ h6 {
   }
 }
 
+@media (max-width: 768px) {
+  :root {
+    --hero-top-spacing: clamp(7.4rem, 7vw + 3.6rem, 9.6rem);
+    --hero-bottom-spacing: clamp(6.2rem, 5.5vw + 2.6rem, 8.1rem);
+  }
+}
+
 @media (max-width: 640px) {
   :root {
-    --hero-top-spacing: clamp(6.6rem, 7vw + 3rem, 8.6rem);
-    --hero-bottom-spacing: clamp(5.9rem, 6vw + 2.4rem, 7.6rem);
+    --hero-top-spacing: clamp(7.8rem, 8vw + 3.8rem, 10.5rem);
+    --hero-bottom-spacing: clamp(6.5rem, 6vw + 2.8rem, 8.2rem);
   }
 }
 
@@ -1112,8 +1119,13 @@ h6 {
   }
 
   .hero-section-spacing {
-    padding-top: clamp(5.5rem, 8vw + 2.9rem, 6.75rem);
-    padding-bottom: clamp(3.8rem, 10vw, 4.9rem);
+    padding-top: var(--hero-top-spacing);
+    padding-bottom: clamp(4.3rem, 9vw + 2.2rem, var(--hero-bottom-spacing));
+  }
+
+  .hero-section-spacing.hero-extra-top,
+  .hero-extra-top {
+    padding-top: calc(var(--hero-top-spacing) + clamp(1rem, 2.5vw + 0.6rem, 2.2rem));
   }
 
   .hero-minimal {
@@ -1123,6 +1135,7 @@ h6 {
 
   .hero-minimal__container {
     padding-inline: clamp(1.1rem, 5vw, 1.5rem);
+    padding-top: clamp(0.75rem, 2.5vw, 1.6rem);
   }
 
   .hero-minimal__content {
@@ -1234,6 +1247,10 @@ h6 {
     gap: 1.35rem;
   }
 
+  .industries-pills {
+    display: none;
+  }
+
   .stat-card,
   .feature-grid-card {
     padding: clamp(1.45rem, 5vw, 1.9rem);
@@ -1258,10 +1275,12 @@ h6 {
 
   .service-card {
     border-radius: 24px;
+    box-shadow: 0 22px 54px -38px rgba(6, 27, 46, 0.42);
+    transition-duration: 0.28s;
   }
 
   .service-card__visual {
-    aspect-ratio: 5 / 4;
+    aspect-ratio: 4 / 3;
   }
 
   .service-card__badge {
@@ -1270,8 +1289,115 @@ h6 {
   }
 
   .service-card__body {
-    padding: 1.6rem 1.3rem 1.9rem;
-    gap: 1rem;
+    padding: 1.65rem 1.35rem 2rem;
+    gap: 1.05rem;
+  }
+
+  .services-carousel {
+    display: flex;
+    flex-direction: column;
+    gap: 1.4rem;
+    margin-top: 0.5rem;
+  }
+
+  .services-carousel__header {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.85rem;
+  }
+
+  .services-carousel__copy {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .services-carousel__title {
+    margin: 0;
+    font-size: 1.28rem;
+    font-weight: 700;
+    color: #0a2233;
+    text-wrap: balance;
+  }
+
+  .services-carousel__description {
+    margin-top: 0.35rem;
+    font-size: 1.02rem;
+    line-height: 1.6;
+    color: rgba(9, 32, 53, 0.74);
+    text-wrap: pretty;
+  }
+
+  .services-carousel__controls {
+    display: inline-flex;
+    align-self: flex-end;
+    align-items: center;
+    gap: 0.55rem;
+  }
+
+  .services-carousel__control {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.65rem;
+    height: 2.65rem;
+    border-radius: 999px;
+    border: 1px solid rgba(13, 161, 225, 0.24);
+    background: rgba(255, 255, 255, 0.97);
+    color: #0da1e1;
+    box-shadow: 0 18px 36px -28px rgba(5, 31, 52, 0.42);
+    transition: background 0.28s ease, color 0.28s ease, border-color 0.28s ease;
+  }
+
+  .services-carousel__control:active {
+    background: rgba(13, 161, 225, 0.12);
+  }
+
+  .services-carousel__control:focus-visible {
+    outline: 3px solid rgba(13, 161, 225, 0.35);
+    outline-offset: 3px;
+  }
+
+  .services-carousel__track {
+    display: flex;
+    gap: 1.35rem;
+    overflow-x: auto;
+    padding-bottom: 0.4rem;
+    margin-inline: -0.35rem;
+    padding-inline: 0.35rem;
+    scroll-snap-type: x mandatory;
+    scroll-snap-stop: always;
+    scroll-padding-left: 0.35rem;
+    -webkit-overflow-scrolling: touch;
+    touch-action: pan-y;
+    scroll-behavior: smooth;
+  }
+
+  .services-carousel__track::-webkit-scrollbar {
+    display: none;
+  }
+
+  .services-carousel__card {
+    flex: 0 0 78%;
+    min-width: 78%;
+    max-width: 78%;
+    scroll-snap-align: start;
+  }
+
+  .services-carousel__card .service-card__body {
+    min-height: clamp(16rem, 64vw, 19rem);
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+  }
+
+  .services-carousel__card .service-card__title {
+    font-size: 1.32rem;
+  }
+
+  .services-carousel__card .service-card__description {
+    font-size: 0.96rem;
+    line-height: 1.65;
   }
 
   .testimonial-carousel {
@@ -1329,7 +1455,69 @@ h6 {
   }
 
   .quote-section__form {
+    width: min(100%, 540px);
+    margin-inline: clamp(-0.6rem, -3vw, -1.1rem);
+  }
+
+  .quote-form {
+    padding: 2.1rem 1.75rem;
+    border-radius: 24px;
+    border: 1px solid rgba(13, 161, 225, 0.16);
+    background: linear-gradient(150deg, rgba(255, 255, 255, 0.96), rgba(240, 248, 255, 0.92));
+    box-shadow: 0 24px 52px -32px rgba(15, 23, 42, 0.42);
+  }
+
+  .quote-form > .pointer-events-none {
+    display: none;
+  }
+
+  .quote-form__header {
+    align-items: flex-start;
+    text-align: left;
+    gap: 1rem;
+  }
+
+  .quote-form__intro {
     width: 100%;
+  }
+
+  .quote-form__title {
+    font-size: 1.6rem !important;
+    line-height: 1.25;
+  }
+
+  .quote-form__subtitle {
+    font-size: 0.96rem !important;
+    line-height: 1.65;
+    color: rgba(11, 34, 51, 0.78);
+  }
+
+  .quote-form__badge {
+    align-self: flex-start;
+    padding-inline: 1rem;
+    padding-block: 0.6rem;
+    font-size: 0.66rem;
+    letter-spacing: 0.24em;
+    border-color: rgba(13, 161, 225, 0.22);
+    background: rgba(255, 255, 255, 0.94);
+    color: rgba(11, 34, 51, 0.72);
+    box-shadow: 0 12px 26px -18px rgba(11, 34, 51, 0.35);
+  }
+
+  .quote-form input,
+  .quote-form textarea {
+    font-size: 1.02rem;
+    padding: 0.85rem 1rem;
+    border-radius: 18px;
+    border-color: rgba(13, 161, 225, 0.18);
+    box-shadow: 0 10px 22px -18px rgba(9, 41, 74, 0.25);
+  }
+
+  .quote-form button {
+    font-size: 1.05rem;
+    padding-block: 1rem;
+    border-radius: 18px;
+    box-shadow: 0 22px 44px -26px rgba(13, 161, 225, 0.45);
   }
 
   .faq-accordion-card {

--- a/src/components/QuoteForm.tsx
+++ b/src/components/QuoteForm.tsx
@@ -79,12 +79,12 @@ const QuoteForm: React.FC<QuoteFormProps> = ({
       <div className="pointer-events-none absolute -bottom-16 left-6 h-40 w-40 rounded-full bg-fresh-green/20 blur-3xl"></div>
 
       <div className="relative">
-        <div className="flex flex-col items-center gap-4 text-center sm:flex-row sm:items-center sm:justify-between sm:gap-5 sm:text-left">
-          <div>
-            <h3 className="text-2xl font-bold text-charcoal sm:text-[1.65rem]">{title}</h3>
-            <p className="mt-1 text-sm text-jet/80 sm:text-base">{subtitle}</p>
+        <div className="quote-form__header flex flex-col items-center gap-4 text-center sm:flex-row sm:items-center sm:justify-between sm:gap-5 sm:text-left">
+          <div className="quote-form__intro">
+            <h3 className="quote-form__title text-2xl font-bold text-charcoal sm:text-[1.65rem]">{title}</h3>
+            <p className="quote-form__subtitle mt-1 text-sm text-jet/80 sm:text-base">{subtitle}</p>
           </div>
-          <div className="inline-flex items-center justify-center gap-2 rounded-full border border-ash-gray/40 bg-white/85 px-4 py-2 text-[0.7rem] font-semibold uppercase tracking-[0.3em] text-charcoal/70 shadow-sm sm:self-center">
+          <div className="quote-form__badge inline-flex items-center justify-center gap-2 rounded-full border border-ash-gray/40 bg-white/85 px-4 py-2 text-[0.7rem] font-semibold uppercase tracking-[0.3em] text-charcoal/70 shadow-sm sm:self-center">
             <span className="whitespace-nowrap">24hr Reply</span>
           </div>
         </div>
@@ -104,6 +104,7 @@ const QuoteForm: React.FC<QuoteFormProps> = ({
                 onChange={handleChange}
                 className={inputClasses}
                 placeholder="Your full name"
+                autoComplete="name"
               />
             </div>
 
@@ -120,6 +121,8 @@ const QuoteForm: React.FC<QuoteFormProps> = ({
                 onChange={handleChange}
                 className={inputClasses}
                 placeholder="0411 820 650"
+                autoComplete="tel"
+                inputMode="tel"
               />
             </div>
           </div>
@@ -137,6 +140,7 @@ const QuoteForm: React.FC<QuoteFormProps> = ({
               onChange={handleChange}
               className={inputClasses}
               placeholder="your.email@company.com"
+              autoComplete="email"
             />
           </div>
 
@@ -152,6 +156,7 @@ const QuoteForm: React.FC<QuoteFormProps> = ({
               onChange={handleChange}
               className={`${inputClasses} min-h-[140px] resize-none sm:min-h-[170px]`}
               placeholder="Facility type, approximate size, frequency required, any compliance notes."
+              autoComplete="off"
             ></textarea>
           </div>
 

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Link } from 'react-router-dom';
 import {
   Shield,
@@ -6,6 +6,7 @@ import {
   Users,
   CheckCircle,
   Star,
+  ArrowLeft,
   ArrowRight,
   Building2,
   Dumbbell,
@@ -31,6 +32,20 @@ import HowItWorks from '../components/HowItWorks';
 
 const Home: React.FC = () => {
   const scrollToServices = useScrollToSection('services');
+  const servicesCarouselRef = useRef<HTMLDivElement | null>(null);
+
+  const scrollServicesCarousel = (direction: 'previous' | 'next') => {
+    const node = servicesCarouselRef.current;
+    if (!node) {
+      return;
+    }
+
+    const scrollAmount = node.clientWidth * 0.88;
+    node.scrollBy({
+      left: direction === 'next' ? scrollAmount : -scrollAmount,
+      behavior: 'smooth',
+    });
+  };
 
   const heroHighlights = [
     {
@@ -401,7 +416,7 @@ const Home: React.FC = () => {
               </div>
             ))}
           </div>
-          <div className="mt-8 flex flex-wrap justify-center gap-3 text-sm font-medium uppercase tracking-wide text-jet/70">
+          <div className="industries-pills mt-8 flex flex-wrap justify-center gap-3 text-sm font-medium uppercase tracking-wide text-jet/70">
             {industriesServed.map((industry) => (
               <span key={industry} className="pill-chip bg-white text-charcoal">
                 {industry}
@@ -466,7 +481,67 @@ const Home: React.FC = () => {
               Choose the program tailored to your industry. Each page highlights the specifics, results and pricing guidance you need.
             </p>
           </div>
-          <div className="grid grid-cols-1 gap-8 md:grid-cols-2 xl:grid-cols-3">
+          <div className="services-carousel md:hidden" aria-label="Swipeable list of cleaning service programs">
+            <div className="services-carousel__header">
+              <div className="services-carousel__copy">
+                <h3 className="services-carousel__title">Explore our specialist programs</h3>
+                <p className="services-carousel__description">
+                  Swipe or tap the arrows to open the cleaning pathway tailored to your facility.
+                </p>
+              </div>
+              <div className="services-carousel__controls" role="group" aria-label="Service carousel controls">
+                <button
+                  type="button"
+                  className="services-carousel__control"
+                  aria-label="View previous service"
+                  onClick={() => scrollServicesCarousel('previous')}
+                >
+                  <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+                </button>
+                <button
+                  type="button"
+                  className="services-carousel__control"
+                  aria-label="View next service"
+                  onClick={() => scrollServicesCarousel('next')}
+                >
+                  <ArrowRight className="h-4 w-4" aria-hidden="true" />
+                </button>
+              </div>
+            </div>
+            <div
+              ref={servicesCarouselRef}
+              className="services-carousel__track"
+              aria-live="polite"
+            >
+              {services.map((service) => (
+                <Link key={service.name} to={service.path} className="service-card group services-carousel__card">
+                  <div className="service-card__visual">
+                    <img
+                      src={service.image}
+                      alt={`${service.name} cleaning in Brisbane`}
+                      className="service-card__image"
+                      loading="lazy"
+                      decoding="async"
+                    />
+                    <span className="service-card__badge">
+                      <service.icon className="h-4 w-4" aria-hidden="true" />
+                      {service.name}
+                    </span>
+                  </div>
+                  <div className="service-card__body">
+                    <span className="service-card__eyebrow">Tailored program</span>
+                    <h3 className="service-card__title">{service.name}</h3>
+                    <p className="service-card__description">{service.description}</p>
+                    <span className="service-card__cta">
+                      Explore program
+                      <ArrowRight className="h-4 w-4" aria-hidden="true" />
+                    </span>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          </div>
+          <div className="hidden gap-8 md:grid md:grid-cols-2 xl:grid-cols-3">
             {services.map((service) => (
               <Link key={service.name} to={service.path} className="service-card group">
                 <div className="service-card__visual">


### PR DESCRIPTION
## Summary
- increase mobile hero spacing and hide the industry pill row so the header no longer overlaps on phones
- refresh the mobile services carousel copy, spacing, and touch behaviour to keep cards consistent without hint text
- widen and lighten the mobile quote form styling to feel more polished and responsive

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3a760c0988327bc875d74f485e7f7