### PR TITLE
Refine mobile service cards

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1364,7 +1364,7 @@ h6 {
     scroll-snap-stop: always;
     scroll-padding-left: 0.35rem;
     -webkit-overflow-scrolling: touch;
-    touch-action: pan-y;
+    touch-action: pan-x pinch-zoom;
     scroll-behavior: smooth;
   }
 
@@ -1393,6 +1393,121 @@ h6 {
   .services-carousel__card .service-card__description {
     font-size: 0.96rem;
     line-height: 1.65;
+  }
+
+  @media (max-width: 767px) {
+    .services-carousel {
+      gap: 1.85rem;
+    }
+
+    .services-carousel__track {
+      gap: 1.1rem;
+      margin-inline: -0.5rem;
+      padding-inline: 0.5rem;
+    }
+
+    .services-carousel__card {
+      flex: 0 0 88%;
+      min-width: 88%;
+      max-width: 88%;
+      border-radius: 24px;
+      border: 1px solid rgba(13, 161, 225, 0.18);
+      background: linear-gradient(155deg, rgba(255, 255, 255, 0.98), rgba(229, 244, 255, 0.95));
+      box-shadow: 0 32px 70px -48px rgba(5, 31, 52, 0.65);
+      overflow: hidden;
+      transition: none;
+    }
+
+    .services-carousel__card:focus-visible {
+      outline: 3px solid rgba(13, 161, 225, 0.32);
+      outline-offset: 4px;
+    }
+
+    .services-carousel__card:hover,
+    .services-carousel__card:focus-visible {
+      transform: none;
+      border-color: rgba(13, 161, 225, 0.18);
+      box-shadow: 0 32px 70px -48px rgba(5, 31, 52, 0.65);
+    }
+
+    .services-carousel__card .service-card__visual {
+      aspect-ratio: auto;
+      min-height: clamp(11.5rem, 52vw, 13.5rem);
+    }
+
+    .services-carousel__card .service-card__visual::after {
+      opacity: 0.45;
+    }
+
+    .services-carousel__card .service-card__image {
+      transform: scale(1.04);
+    }
+
+    .services-carousel__card .service-card__badge {
+      top: clamp(1rem, 2.2vw, 1.25rem);
+      bottom: auto;
+      left: clamp(1rem, 2.2vw, 1.25rem);
+      padding: 0.45rem 0.95rem;
+      font-size: 0.68rem;
+      letter-spacing: 0.2em;
+      background: rgba(255, 255, 255, 0.85);
+      box-shadow: 0 18px 32px -30px rgba(5, 24, 38, 0.5);
+    }
+
+    .services-carousel__card .service-card__body {
+      min-height: auto;
+      gap: 0.9rem;
+      padding: 1.55rem 1.35rem 1.85rem;
+    }
+
+    .services-carousel__card .service-card__eyebrow {
+      font-size: 0.7rem;
+      letter-spacing: 0.28em;
+    }
+
+    .services-carousel__card .service-card__title {
+      font-size: 1.38rem;
+      line-height: 1.25;
+    }
+
+    .services-carousel__card .service-card__description {
+      font-size: 0.98rem;
+      line-height: 1.65;
+      color: rgba(9, 32, 53, 0.78);
+    }
+
+    .services-carousel__card .service-card__cta {
+      margin-top: 0.6rem;
+      font-size: 0.95rem;
+      color: #0a2233;
+    }
+
+    .services-carousel__card .service-card__cta svg {
+      width: 1.1rem;
+      height: 1.1rem;
+      transform: none;
+    }
+
+    .services-carousel__card:hover .service-card__image,
+    .services-carousel__card:focus-visible .service-card__image {
+      transform: scale(1.04);
+      filter: saturate(1.05);
+    }
+
+    .services-carousel__card:hover .service-card__visual::after,
+    .services-carousel__card:focus-visible .service-card__visual::after {
+      opacity: 0.45;
+    }
+
+    .services-carousel__card:hover .service-card__cta,
+    .services-carousel__card:focus-visible .service-card__cta {
+      color: #0a2233;
+    }
+
+    .services-carousel__card:hover .service-card__cta svg,
+    .services-carousel__card:focus-visible .service-card__cta svg {
+      transform: none;
+    }
   }
 
   .testimonial-carousel {


### PR DESCRIPTION
## Summary
- refresh the mobile service carousel styling with updated spacing, card surfaces, and typography
- restore swipe support on touch devices by allowing horizontal pan gestures
- remove hover/touch motion from the mobile service cards while keeping desktop behaviour unchanged

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3b8efe5d4832790c0975fcf12619c