### PR TITLE
Add Apache fallback routing for service pages

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,0 +1,15 @@
+<IfModule mod_rewrite.c>
+  RewriteEngine On
+  RewriteBase /
+
+  # Allow direct access to existing files and directories (including PHP endpoints)
+  RewriteCond %{REQUEST_FILENAME} -f [OR]
+  RewriteCond %{REQUEST_FILENAME} -d
+  RewriteRule ^ - [L]
+
+  # Fallback all other requests to the SPA entry point for client-side routing
+  RewriteRule ^ index.html [L]
+</IfModule>
+
+# Provide a sensible fallback when mod_rewrite is unavailable
+FallbackResource /index.html


### PR DESCRIPTION
## Summary
- add an .htaccess file so Apache falls back to index.html for client-side routes
- preserve access to existing assets and PHP endpoints while handling SPA deep links

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4a11c6fb083279a03358859195600