### PR TITLE
Update sitemap to prioritise service pages

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://mogcleaning.com.au/</loc>
@@ -6,48 +6,33 @@
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://mogcleaning.com.au/about</loc>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://mogcleaning.com.au/process</loc>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://mogcleaning.com.au/contact</loc>
-    <changefreq>weekly</changefreq>
-    <priority>0.9</priority>
-  </url>
-  <url>
     <loc>https://mogcleaning.com.au/services/offices</loc>
     <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://mogcleaning.com.au/services/fitness</loc>
     <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://mogcleaning.com.au/services/health</loc>
     <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://mogcleaning.com.au/services/education</loc>
     <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://mogcleaning.com.au/services/hospitality</loc>
     <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://mogcleaning.com.au/services/retail</loc>
     <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.9</priority>
   </url>
 </urlset>


### PR DESCRIPTION
## Summary
- focus the sitemap on the homepage and individual service pages so they receive the highest crawl priority

## Testing
- not run (not required)

------
https://chatgpt.com/codex/tasks/task_e_68e4acebd7608327975c573e63f6beb9