### PR TITLE
Prevent thank-you page indexing

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
-Disallow:
+Disallow: /thank-you
 
 Sitemap: https://mogcleaning.com.au/sitemap.xml


### PR DESCRIPTION
## Summary
- update robots.txt to disallow crawling of the thank-you page so it is not indexed

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4afeca9108327a338ed02b7d423dd