### PR TITLE
Add Google Ads conversion tracking configuration

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,15 +33,34 @@
       />
     </noscript>
     <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-PJ1MB2NTCL"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag() {
-        dataLayer.push(arguments);
+    <script type="module">
+      const measurementId = import.meta.env.VITE_GA_MEASUREMENT_ID;
+      const adsId = import.meta.env.VITE_GOOGLE_ADS_ID;
+      const loaderId = adsId || measurementId;
+
+      if (loaderId) {
+        const script = document.createElement('script');
+        script.async = true;
+        script.src = `https://www.googletagmanager.com/gtag/js?id=${encodeURIComponent(loaderId)}`;
+        document.head.appendChild(script);
       }
+
+      window.dataLayer = window.dataLayer || [];
+
+      function gtag() {
+        window.dataLayer.push(arguments);
+      }
+
+      window.gtag = gtag;
       gtag('js', new Date());
 
-      gtag('config', 'G-PJ1MB2NTCL', { send_page_view: false });
+      if (measurementId) {
+        gtag('config', measurementId, { send_page_view: false });
+      }
+
+      if (adsId) {
+        gtag('config', adsId);
+      }
     </script>
   </head>
   <body>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,7 +17,8 @@ import ThankYou from './pages/ThankYou';
 import useScrollMotion from './hooks/useScrollMotion';
 import './App.css';
 
-const GA_MEASUREMENT_ID = 'G-PJ1MB2NTCL';
+const GA_MEASUREMENT_ID = import.meta.env.VITE_GA_MEASUREMENT_ID;
+const GOOGLE_ADS_ID = import.meta.env.VITE_GOOGLE_ADS_ID;
 
 declare global {
   interface Window {
@@ -47,9 +48,19 @@ const AppRoutes: React.FC = () => {
       return;
     }
 
-    window.gtag('config', GA_MEASUREMENT_ID, {
-      page_path: `${location.pathname}${location.search}${location.hash}`,
-    });
+    const pagePath = `${location.pathname}${location.search}${location.hash}`;
+
+    if (GA_MEASUREMENT_ID) {
+      window.gtag('config', GA_MEASUREMENT_ID, {
+        page_path: pagePath,
+      });
+    }
+
+    if (GOOGLE_ADS_ID) {
+      window.gtag('config', GOOGLE_ADS_ID, {
+        page_path: pagePath,
+      });
+    }
   }, [location.pathname, location.search, location.hash]);
 
   return (

--- a/src/components/QuoteForm.tsx
+++ b/src/components/QuoteForm.tsx
@@ -8,6 +8,11 @@ interface QuoteFormProps {
   className?: string;
 }
 
+const GOOGLE_ADS_ID = import.meta.env.VITE_GOOGLE_ADS_ID;
+const GOOGLE_ADS_CONVERSION_LABEL = import.meta.env.VITE_GOOGLE_ADS_CONVERSION_LABEL;
+const GOOGLE_ADS_CONVERSION_VALUE = import.meta.env.VITE_GOOGLE_ADS_CONVERSION_VALUE;
+const GOOGLE_ADS_CONVERSION_CURRENCY = import.meta.env.VITE_GOOGLE_ADS_CONVERSION_CURRENCY;
+
 const QuoteForm: React.FC<QuoteFormProps> = ({
   title = 'Get Your Free Quote',
   subtitle = 'No obligation. Response within 24 hours.',
@@ -48,6 +53,24 @@ const QuoteForm: React.FC<QuoteFormProps> = ({
       const data = await res.json().catch(() => null);
 
       if (res.ok && data && data.success) {
+        if (typeof window !== 'undefined' && typeof window.gtag === 'function' && GOOGLE_ADS_ID && GOOGLE_ADS_CONVERSION_LABEL) {
+          const conversionPayload: Record<string, unknown> = {
+            send_to: `${GOOGLE_ADS_ID}/${GOOGLE_ADS_CONVERSION_LABEL}`,
+          };
+
+          const parsedValue = GOOGLE_ADS_CONVERSION_VALUE ? Number(GOOGLE_ADS_CONVERSION_VALUE) : undefined;
+
+          if (!Number.isNaN(parsedValue) && parsedValue !== undefined) {
+            conversionPayload.value = parsedValue;
+          }
+
+          if (GOOGLE_ADS_CONVERSION_CURRENCY) {
+            conversionPayload.currency = GOOGLE_ADS_CONVERSION_CURRENCY;
+          }
+
+          window.gtag('event', 'conversion', conversionPayload);
+        }
+
         setFormData({ name: '', phone: '', email: '', message: '' });
         navigate('/thank-you');
       } else {


### PR DESCRIPTION
## Summary
- initialize Google Ads alongside GA4 in the global tag loader using environment variables
- load Google Ads config on client-side navigations
- fire a conversion event when a quote submission succeeds, with metadata sourced from env vars

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68e56f8fa4788327b784d10459848359