### PR TITLE
Fix PHP contact handler to restore email delivery

### DIFF
--- a/php/contact.php
+++ b/php/contact.php
@@ -1,125 +1,132 @@
 <?php
+
+declare(strict_types=1);
+
 header('Content-Type: application/json; charset=UTF-8');
 
- = [
+$allowedOrigins = [
     'https://mogclean.com.au',
     'https://mogcleaning.com.au',
 ];
 
- = ['HTTP_ORIGIN'] ?? '';
- = preg_match('#^https?://(localhost|127\.0\.0\.1)(:\d+)?$#', ) === 1;
+$origin = $_SERVER['HTTP_ORIGIN'] ?? '';
+$isLocalhost = preg_match('#^https?://(localhost|127\.0\.0\.1)(:\d+)?$#', $origin) === 1;
 
-if (in_array(, , true) || ) {
-    header('Access-Control-Allow-Origin: ' . );
+if (in_array($origin, $allowedOrigins, true) || $isLocalhost) {
+    header('Access-Control-Allow-Origin: ' . $origin);
     header('Vary: Origin');
 }
 
 header('Access-Control-Allow-Methods: POST, OPTIONS');
 header('Access-Control-Allow-Headers: Content-Type');
 
-if (['REQUEST_METHOD'] === 'OPTIONS') {
+if (($_SERVER['REQUEST_METHOD'] ?? '') === 'OPTIONS') {
     http_response_code(204);
     exit;
 }
 
-use PHPMailer\PHPMailer\PHPMailer;
-use PHPMailer\PHPMailer\Exception;
-
- = __DIR__ . '/vendor/autoload.php';
-if (is_readable()) {
-    require ;
+$autoloadPath = __DIR__ . '/vendor/autoload.php';
+if (is_readable($autoloadPath)) {
+    require $autoloadPath;
 } else {
     require __DIR__ . '/phpmailer/src/PHPMailer.php';
     require __DIR__ . '/phpmailer/src/SMTP.php';
     require __DIR__ . '/phpmailer/src/Exception.php';
 }
 
- = false;
- = '/home/iupaxipp/config.php';
-if (is_readable()) {
-    require ;
-     = true;
+$configLoaded = false;
+$primaryConfigPath = '/home/iupaxipp/config.php';
+if (is_readable($primaryConfigPath)) {
+    require $primaryConfigPath;
+    $configLoaded = true;
 }
 
-if (!) {
-     = __DIR__ . '/config.php';
-    if (is_readable()) {
-        require ;
-         = true;
+if (!$configLoaded) {
+    $localConfigPath = __DIR__ . '/config.php';
+    if (is_readable($localConfigPath)) {
+        require $localConfigPath;
+        $configLoaded = true;
     }
 }
 
-if (!) {
+if (!$configLoaded) {
     http_response_code(500);
     echo json_encode(['success' => false, 'message' => 'Mail configuration missing.']);
     exit;
 }
 
-if (['REQUEST_METHOD'] !== 'POST') {
+if (($_SERVER['REQUEST_METHOD'] ?? '') !== 'POST') {
     echo json_encode(['success' => false, 'message' => 'Invalid request']);
     exit;
 }
 
- = filter_input(INPUT_POST, 'name', FILTER_SANITIZE_STRING) ?? '';
- = filter_input(INPUT_POST, 'email', FILTER_SANITIZE_EMAIL) ?? '';
- = filter_input(INPUT_POST, 'message', FILTER_SANITIZE_STRING) ?? '';
- = filter_input(INPUT_POST, 'phone', FILTER_SANITIZE_STRING) ?? '';
+$rawName = filter_input(INPUT_POST, 'name', FILTER_UNSAFE_RAW, FILTER_FLAG_STRIP_LOW | FILTER_FLAG_STRIP_HIGH) ?? '';
+$name = trim(strip_tags($rawName));
+$emailValue = filter_input(INPUT_POST, 'email', FILTER_VALIDATE_EMAIL);
+$message = trim(filter_input(INPUT_POST, 'message', FILTER_UNSAFE_RAW) ?? '');
+$phone = trim(filter_input(INPUT_POST, 'phone', FILTER_UNSAFE_RAW) ?? '');
 
-if ( === '' ||  === '' ||  === '') {
+if ($emailValue === false || $emailValue === null) {
+    echo json_encode(['success' => false, 'message' => 'A valid email address is required']);
+    exit;
+}
+
+$email = trim($emailValue);
+
+if ($name === '' || $message === '') {
     echo json_encode(['success' => false, 'message' => 'All fields are required']);
     exit;
 }
 
- = new PHPMailer(true);
-
 try {
-    ->isSMTP();
-    ->Host = SMTP_HOST;
-    ->SMTPAuth = true;
-    ->Username = SMTP_USER;
-    ->Password = SMTP_PASS;
-    ->SMTPSecure = PHPMailer::ENCRYPTION_SMTPS;
-    ->Port = SMTP_PORT;
+    $mail = new PHPMailer\PHPMailer\PHPMailer(true);
 
-    ->setFrom(SMTP_USER, 'MOG Clean Website');
-    ->addAddress('quotes@mogcleaning.com.au', 'MOG Cleaning');
-    ->addReplyTo(, );
+    $mail->isSMTP();
+    $mail->Host = SMTP_HOST;
+    $mail->SMTPAuth = true;
+    $mail->Username = SMTP_USER;
+    $mail->Password = SMTP_PASS;
+    $mail->SMTPSecure = PHPMailer\PHPMailer\PHPMailer::ENCRYPTION_SMTPS;
+    $mail->Port = SMTP_PORT;
 
-    ->isHTML(false);
-    ->Subject = 'New Contact Form Submission';
+    $mail->setFrom(SMTP_USER, 'MOG Cleaning Website');
+    $mail->addAddress('quotes@mogcleaning.com.au', 'MOG Cleaning');
+    $mail->addReplyTo($email, $name);
 
-     = [
-        "Name: {}",
-        "Email: {}",
+    $bodyLines = [
+        "Name: {$name}",
+        "Email: {$email}",
     ];
 
-    if ( !== '') {
-        [] = "Phone: {}";
+    if ($phone !== '') {
+        $bodyLines[] = "Phone: {$phone}";
     }
 
-    [] = 'Message:';
-    [] = ;
+    $bodyLines[] = 'Message:';
+    $bodyLines[] = $message;
 
-    ->Body = implode("\n", );
+    $mail->isHTML(false);
+    $mail->Subject = 'New Contact Form Submission';
+    $mail->Body = implode("\n", $bodyLines);
 
-    ->send();
+    $mail->send();
 
     echo json_encode(['success' => true, 'message' => 'Message sent successfully']);
-} catch (Exception ) {
-     = '/home/iupaxipp/mail_logs';
-    if (!is_dir()) {
-        mkdir(, 0700, true);
+} catch (PHPMailer\PHPMailer\Exception $e) {
+    $logDirectory = '/home/iupaxipp/mail_logs';
+    if (!is_dir($logDirectory)) {
+        mkdir($logDirectory, 0700, true);
     }
 
-     =  . '/mail_errors.log';
-     = '[' . date('Y-m-d H:i:s') . '] ' .
-        "From: {} <{}>" . PHP_EOL .
-        'Phone: ' . ( !== '' ?  : 'N/A') . PHP_EOL .
-        'Message: ' .  . PHP_EOL .
-        'Error: ' . ->ErrorInfo . PHP_EOL .
+    $logFile = $logDirectory . '/mail_errors.log';
+    $logEntry = '[' . date('Y-m-d H:i:s') . '] ' .
+        "From: {$name} <{$email}>" . PHP_EOL .
+        'Phone: ' . ($phone !== '' ? $phone : 'N/A') . PHP_EOL .
+        'Message: ' . $message . PHP_EOL .
+        'Error: ' . $e->getMessage() . PHP_EOL .
         str_repeat('-', 50) . PHP_EOL;
 
-    file_put_contents(, , FILE_APPEND);
+    file_put_contents($logFile, $logEntry, FILE_APPEND);
 
-    echo json_encode(['success' => false, 'message' => 'Mailer Error: ' . ->ErrorInfo]);
+    echo json_encode(['success' => false, 'message' => 'Mailer Error: ' . $e->getMessage()]);
 }


### PR DESCRIPTION
## Summary
- restore all PHP variables and logic in `php/contact.php` that were lost, enabling form handling again
- harden sanitisation, validation, and configuration loading for the contact form endpoint
- keep logging for mail errors while returning JSON responses for frontend compatibility

## Testing
- not run (PHP script change only)


------
https://chatgpt.com/codex/tasks/task_e_68e764e715908327bead1bf05e0c1b5c